### PR TITLE
Remove log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,23 @@
 This project provides a command line interface (cli) Bitcoin wallet library and [`REPL`](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)
 wallet tool based on the [bdk](https://github.com/bitcoindevkit/bdk) library.
 
-### How to run the REPL tool
+### REPL wallet usage examples
 
-To run the REPL tool use the below command which returns the list of available wallet options and
-commands:
+To get usage information for the `repl` wallet tool use the below command which
+returns a list of available wallet options and commands:
 
 ```shell
 cargo run
+```
+
+To sync a wallet to the default electrum server:
+
+```shell
+cargo run -- --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+```
+
+To get a wallet balance with customized logging:
+
+```shell
+RUST_LOG=debug,sled=info,rustls=info cargo run -- --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" get_balance
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,9 +183,6 @@ pub struct WalletOpt {
     /// Sets the descriptor to use for internal addresses
     #[structopt(name = "CHANGE_DESCRIPTOR", short = "c", long = "change_descriptor")]
     pub change_descriptor: Option<String>,
-    /// Sets the logging level filter (off, error, warn, info, debug, trace)
-    #[structopt(long = "log_level", short = "l", default_value = "info")]
-    pub log_level: String,
     #[cfg(feature = "esplora")]
     /// Use the esplora server if given as parameter
     #[structopt(name = "ESPLORA_URL", short = "e", long = "esplora")]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use bitcoin::Network;
 use clap::AppSettings;
-use log::{debug, info, warn, LevelFilter};
+use log::{debug, info, warn};
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use structopt::StructOpt;
@@ -69,10 +69,9 @@ fn prepare_home_dir() -> PathBuf {
 }
 
 fn main() {
-    let cli_opt: WalletOpt = WalletOpt::from_args();
+    env_logger::init();
 
-    let level = LevelFilter::from_str(cli_opt.log_level.as_str()).unwrap_or(LevelFilter::Info);
-    env_logger::builder().filter_level(level).init();
+    let cli_opt: WalletOpt = WalletOpt::from_args();
 
     let network = Network::from_str(cli_opt.network.as_str()).unwrap_or(Network::Testnet);
     debug!("network: {:?}", network);


### PR DESCRIPTION
### Description

This issue fixes #1 by removing the `--log_level` option which was overriding the `RUST_LOG` environment variable but does not provide the same level of logging control.

### Notes to the reviewers

Also in this PR I added a couple more usage examples in the README, including an example for using the `RUST_LOG` env variable.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
