### PR TITLE
Add network parser function to lib.rs, remove network parsing from repl.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Project
+#### Added
+- Add CONTRIBUTING.md
+- Add CI and code coverage Discord badges to the README
+- Add CI and code coverage github actions workflows
+- Add scheduled audit check in CI
+- Add CHANGELOG.md
+
+#### Changed
+- If an invalid network name return an error instead of defaulting to `testnet`
+
+## [0.1.0-beta.1]
+
+[unreleased]: https://github.com/bitcoindevkit/bdk-cli/compare/0.1.0-beta.1...HEAD
+[0.1.0-beta.1]: https://github.com/bitcoindevkit/bdk-cli/compare/84a02e35...0.1.0-beta.1
+[bdk0.2]: https://github.com/bitcoindevkit/bdk/releases/tag/v0.2.0

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -24,7 +24,6 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use bitcoin::Network;
@@ -73,7 +72,7 @@ fn main() {
 
     let cli_opt: WalletOpt = WalletOpt::from_args();
 
-    let network = Network::from_str(cli_opt.network.as_str()).unwrap_or(Network::Testnet);
+    let network = cli_opt.network;
     debug!("network: {:?}", network);
     if network == Network::Bitcoin {
         warn!("This is experimental software and not currently recommended for use on Bitcoin mainnet, proceed with caution.")


### PR DESCRIPTION
### Description

This PR moves network parsing to lib.rs and changes repl to return an error instead of defaulting to testnet if an invalid network name is given.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
