### PR TITLE
Re-organize wallet sub-commands and add `key` sub-commands

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -14,7 +14,10 @@ jobs:
           - 1.45.0 # MSRV
         features:
           - default
-          - default,esplora
+          - repl
+          - electrum
+          - esplora
+          - repl,electrum,esplora
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Project
-- Upgrade BDK to `0.3`
 
 #### Added
 - Add support for `wasm`
+- `CliOpts` struct and `CliSubCommand` enum representing top level cli options and commands
+- `KeySubCommand` enum
+- `handle_key_subcommand` function
+
+#### Changed
+- Upgrade BDK to `0.3`
+- Renamed `WalletOpt` struct to `WalletOpts`
+- `WalletSubCommand` enum split into `OfflineWalletSubCommand` and `OnlineWalletSubCommand`
+- Split `handle_wallet_subcommand` into two functions, `handle_offline_wallet_subcommand` and `handle_online_wallet_subcommand`
+- A wallet without a `Blockchain` is used when handling offline wallet sub-commands
+
+### `bdk-cli` bin
+
+#### Added
+- Top level commands "wallet", "key", and "repl"
+- "key" command has sub-commands to "generate" and "restore" a master extended key
+- "repl" command now has an "exit" sub-command
+
+#### Changed
+- "wallet" sub-commands and options must be proceeded by "wallet" command
+- "repl" command loop now includes both "wallet" and "key" sub-commands
 
 ## [0.1.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { git = "https://github.com/afilini/bdk.git", branch = "fix/better-derivable-key-api", features = ["all-keys"]}
-bdk-macros = "^0.2"
+bdk = { git = "https://github.com/bitcoindevkit/bdk.git", commit = "4c36020e", features = ["all-keys"]}
+bdk-macros = { git = "https://github.com/bitcoindevkit/bdk.git", commit = "4c36020e" }
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
 log = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "^0.3", default-features = false }
+bdk = { git = "https://github.com/afilini/bdk.git", branch = "fix/better-derivable-key-api", features = ["all-keys"]}
 bdk-macros = "^0.2"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
@@ -25,10 +25,11 @@ rustyline = { version = "6.0", optional = true }
 dirs-next = { version = "2.0", optional = true }
 env_logger = { version = "0.7", optional = true }
 clap = { version = "2.33", optional = true }
+regex = {version = "1", optional = true }
 
 [features]
-default = ["repl", "esplora", "electrum", "bdk/key-value-db"]
-repl = ["async-trait", "rustyline", "dirs-next", "env_logger", "clap", "electrum"]
+default = ["repl", "electrum"]
+repl = ["async-trait", "rustyline", "dirs-next", "env_logger", "clap", "regex"]
 electrum = ["bdk/electrum"]
 esplora = ["bdk/esplora"]
 compiler = ["bdk/compiler"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { git = "https://github.com/bitcoindevkit/bdk.git", commit = "4c36020e", features = ["all-keys"]}
-bdk-macros = { git = "https://github.com/bitcoindevkit/bdk.git", commit = "4c36020e" }
+bdk = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179", features = ["all-keys"]}
+bdk-macros = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179" }
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
 log = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179", features = ["all-keys"]}
+bdk = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179", default-features = false, features = ["all-keys"]}
 bdk-macros = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179" }
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
@@ -28,8 +28,8 @@ clap = { version = "2.33", optional = true }
 regex = {version = "1", optional = true }
 
 [features]
-default = ["repl", "electrum"]
-repl = ["async-trait", "rustyline", "dirs-next", "env_logger", "clap", "regex"]
+default = []
+repl = ["async-trait", "bdk/key-value-db", "clap", "dirs-next", "env_logger", "regex", "rustyline"]
 electrum = ["bdk/electrum"]
 esplora = ["bdk/esplora"]
 compiler = ["bdk/compiler"]
@@ -37,4 +37,7 @@ compiler = ["bdk/compiler"]
 [[bin]]
 name = "bdk-cli"
 path = "src/bdk_cli.rs"
-required-features = ["repl"]
+required-features = ["repl", "electrum"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ cargo run
 To sync a wallet to the default electrum server:
 
 ```shell
-cargo run -- --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+cargo run -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
 To get a wallet balance with customized logging:
 
 ```shell
-RUST_LOG=debug,sled=info,rustls=info cargo run -- --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" get_balance
+RUST_LOG=debug,sled=info,rustls=info cargo run -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" get_balance
+```
+
+To generate a new extended master key, suitable for using in a descriptor:
+
+```shell
+cargo run -- key generate
 ```

--- a/README.md
+++ b/README.md
@@ -14,23 +14,32 @@ To get usage information for the `bdk-cli` bin use the below command which retur
 available wallet options and commands:
 
 ```shell
-cargo run
+cargo run --features repl,electrum
 ```
 
 To sync a wallet to the default electrum server:
 
 ```shell
-cargo run -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+cargo run --features repl,electrum,esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
 To get a wallet balance with customized logging:
 
 ```shell
-RUST_LOG=debug,sled=info,rustls=info cargo run -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" get_balance
+RUST_LOG=debug,sled=info,rustls=info cargo run --features repl,electrum,esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" get_balance
 ```
 
 To generate a new extended master key, suitable for using in a descriptor:
 
 ```shell
-cargo run -- key generate
+cargo run --features repl,electrum -- key generate
+```
+
+To install dev version of `bdk-cli` from local git repo:
+
+```shell
+cd <bdk-cli git repo directory>
+cargo install --path . --features repl,electrum,esplora
+
+bdk-cli help # to verify it worked
 ```

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -55,7 +55,7 @@ use regex::Regex;
 version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
 struct ReplOpt {
-    /// Wallet sub-command
+    /// Repl sub-command
     #[structopt(subcommand)]
     pub subcommand: ReplSubCommand,
 }

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -51,16 +51,9 @@ use bdk_cli::{
 use regex::Regex;
 
 #[derive(Debug, StructOpt, Clone, PartialEq)]
-#[structopt(name = "", setting = AppSettings::NoBinaryName,
+#[structopt(name = "", long_about = "REPL mode", setting = AppSettings::NoBinaryName, 
 version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
-struct ReplOpt {
-    /// Repl sub-command
-    #[structopt(subcommand)]
-    pub subcommand: ReplSubCommand,
-}
-
-#[derive(Debug, StructOpt, Clone, PartialEq)]
 pub enum ReplSubCommand {
     #[structopt(flatten)]
     OnlineWalletSubCommand(OnlineWalletSubCommand),
@@ -162,8 +155,6 @@ fn main() {
         warn!("This is experimental software and not currently recommended for use on Bitcoin mainnet, proceed with caution.")
     }
 
-    //println!("cli_opts = {:?}", cli_opts);
-
     let result = match cli_opts.subcommand {
         CliSubCommand::Wallet {
             wallet_opts,
@@ -220,16 +211,16 @@ fn main() {
                             .iter()
                             .flat_map(|s| filter_regex.find_iter(s).map(|m| m.as_str()))
                             .collect();
-                        let repl_opt: Result<ReplOpt, clap::Error> =
-                            ReplOpt::from_iter_safe(filtered_line);
-                        debug!("repl_opt = {:?}", repl_opt);
+                        let repl_subcommand: Result<ReplSubCommand, clap::Error> =
+                            ReplSubCommand::from_iter_safe(filtered_line);
+                        debug!("repl_subcommand = {:?}", repl_subcommand);
 
-                        if let Err(err) = repl_opt {
+                        if let Err(err) = repl_subcommand {
                             println!("{}", err.message);
                             continue;
                         }
 
-                        let repl_subcommand = repl_opt.unwrap().subcommand;
+                        let repl_subcommand = repl_subcommand.unwrap();
 
                         let result = match repl_subcommand {
                             ReplSubCommand::OnlineWalletSubCommand(online_subcommand) => {

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -100,8 +100,8 @@ where
     // Try to use Esplora config if "esplora" feature is enabled
     #[cfg(feature = "esplora")]
     let config_esplora: Option<AnyBlockchainConfig> = {
-        let esplora_concurrency = wallet_opts.esplora_concurrency;
-        wallet_opts.esplora.clone().map(|base_url| {
+        let esplora_concurrency = wallet_opts.esplora_opts.esplora_concurrency;
+        wallet_opts.esplora_opts.esplora.clone().map(|base_url| {
             AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
                 base_url,
                 concurrency: Some(esplora_concurrency),
@@ -112,10 +112,10 @@ where
     let config_esplora = None;
 
     let config_electrum = AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
-        url: wallet_opts.electrum.clone(),
-        socks5: wallet_opts.proxy.clone(),
-        retry: wallet_opts.retries,
-        timeout: wallet_opts.timeout,
+        url: wallet_opts.electrum_opts.electrum.clone(),
+        socks5: wallet_opts.electrum_opts.proxy.clone(),
+        retry: wallet_opts.electrum_opts.retries,
+        timeout: wallet_opts.electrum_opts.timeout,
     });
 
     // Fall back to Electrum config if Esplora config isn't provided

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -50,8 +50,9 @@ use bdk_cli::{
 };
 use regex::Regex;
 
+/// REPL mode
 #[derive(Debug, StructOpt, Clone, PartialEq)]
-#[structopt(name = "", long_about = "REPL mode", setting = AppSettings::NoBinaryName, 
+#[structopt(name = "", setting = AppSettings::NoBinaryName, 
 version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
 author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
 pub enum ReplSubCommand {

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -86,30 +86,26 @@ fn prepare_home_dir() -> PathBuf {
     dir
 }
 
-fn main() {
-    env_logger::init();
-
-    let cli_opt: WalletOpt = WalletOpt::from_args();
-
-    let network = cli_opt.network;
-    debug!("network: {:?}", network);
-    if network == Network::Bitcoin {
-        warn!("This is experimental software and not currently recommended for use on Bitcoin mainnet, proceed with caution.")
-    }
-
-    let descriptor = cli_opt.descriptor.as_str();
-    let change_descriptor = cli_opt.change_descriptor.as_deref();
-    debug!("descriptors: {:?} {:?}", descriptor, change_descriptor);
-
+fn open_database(wallet_opts: &WalletOpts) -> Tree {
     let database = sled::open(prepare_home_dir().to_str().unwrap()).unwrap();
-    let tree = database.open_tree(cli_opt.wallet).unwrap();
+    let tree = database.open_tree(&wallet_opts.wallet).unwrap();
     debug!("database opened successfully");
+    tree
+}
 
+fn new_online_wallet<D>(
+    network: Network,
+    wallet_opts: &WalletOpts,
+    database: D,
+) -> Result<Wallet<AnyBlockchain, D>, Error>
+where
+    D: BatchDatabase,
+{
     // Try to use Esplora config if "esplora" feature is enabled
     #[cfg(feature = "esplora")]
     let config_esplora: Option<AnyBlockchainConfig> = {
-        let esplora_concurrency = cli_opt.esplora_concurrency;
-        cli_opt.esplora.map(|base_url| {
+        let esplora_concurrency = wallet_opts.esplora_concurrency;
+        wallet_opts.esplora.clone().map(|base_url| {
             AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
                 base_url,
                 concurrency: Some(esplora_concurrency),
@@ -119,33 +115,96 @@ fn main() {
     #[cfg(not(feature = "esplora"))]
     let config_esplora = None;
 
-    // Fall back to Electrum config if Esplora config isn't provided
-    let config =
-        config_esplora.unwrap_or(AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
-            url: cli_opt.electrum,
-            socks5: cli_opt.proxy,
-            retry: 10,
-            timeout: None,
-        }));
+    let config_electrum = AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
+        url: wallet_opts.electrum.clone(),
+        socks5: wallet_opts.proxy.clone(),
+        retry: wallet_opts.retries,
+        timeout: wallet_opts.timeout,
+    });
 
+    // Fall back to Electrum config if Esplora config isn't provided
+    let config = config_esplora.unwrap_or(config_electrum);
+
+    let descriptor = wallet_opts.descriptor.as_str();
+    let change_descriptor = wallet_opts.change_descriptor.as_deref();
     let wallet = Wallet::new(
         descriptor,
         change_descriptor,
         network,
-        tree,
-        AnyBlockchain::from_config(&config).unwrap(),
-    )
-    .unwrap();
+        database,
+        AnyBlockchain::from_config(&config)?,
+    )?;
+    Ok(wallet)
+}
 
-    let wallet = Arc::new(wallet);
+fn new_offline_wallet<D>(
+    network: Network,
+    wallet_opts: &WalletOpts,
+    database: D,
+) -> Result<Wallet<(), D>, Error>
+where
+    D: BatchDatabase,
+{
+    let descriptor = wallet_opts.descriptor.as_str();
+    let change_descriptor = wallet_opts.change_descriptor.as_deref();
+    let wallet = Wallet::new_offline(descriptor, change_descriptor, network, database)?;
+    Ok(wallet)
+}
 
-    match cli_opt.subcommand {
-        WalletSubCommand::Repl => {
+fn main() {
+    env_logger::init();
+
+    let cli_opts: CliOpts = CliOpts::from_args();
+
+    let network = cli_opts.network;
+    debug!("network: {:?}", network);
+    if network == Network::Bitcoin {
+        warn!("This is experimental software and not currently recommended for use on Bitcoin mainnet, proceed with caution.")
+    }
+
+    //println!("cli_opts = {:?}", cli_opts);
+
+    let result = match cli_opts.subcommand {
+        CliSubCommand::Wallet {
+            wallet_opts,
+            subcommand: WalletSubCommand::OnlineWalletSubCommand(online_subcommand),
+        } => {
+            let database = open_database(&wallet_opts);
+            let wallet = new_online_wallet(network, &wallet_opts, database).unwrap();
+            let result = bdk_cli::handle_online_wallet_subcommand(&wallet, online_subcommand);
+            serde_json::to_string_pretty(&result.unwrap()).unwrap()
+        }
+        CliSubCommand::Wallet {
+            wallet_opts,
+            subcommand: WalletSubCommand::OfflineWalletSubCommand(offline_subcommand),
+        } => {
+            let database = open_database(&wallet_opts);
+            let wallet = new_offline_wallet(network, &wallet_opts, database).unwrap();
+            let result = bdk_cli::handle_offline_wallet_subcommand(&wallet, offline_subcommand);
+            serde_json::to_string_pretty(&result.unwrap()).unwrap()
+        }
+        CliSubCommand::Key {
+            subcommand: key_subcommand,
+        } => {
+            let result = bdk_cli::handle_key_subcommand(network, key_subcommand);
+            serde_json::to_string_pretty(&result.unwrap()).unwrap()
+        }
+        CliSubCommand::Repl { wallet_opts } => {
+            let database = open_database(&wallet_opts);
+            let online_wallet = new_online_wallet(network, &wallet_opts, database.clone()).unwrap();
+            let online_wallet = Arc::new(online_wallet);
+
+            let offline_wallet = new_offline_wallet(network, &wallet_opts, database).unwrap();
+            let offline_wallet = Arc::new(offline_wallet);
+
             let mut rl = Editor::<()>::new();
 
             // if rl.load_history("history.txt").is_err() {
             //     println!("No previous history.");
             // }
+
+            let split_regex = Regex::new(r#"[\w\-]+|"[\w\s]*""#).unwrap();
+            let filter_regex = Regex::new(r#"[\w\s\-]+"#).unwrap();
 
             loop {
                 let readline = rl.readline(">> ");
@@ -155,22 +214,46 @@ fn main() {
                             continue;
                         }
                         rl.add_history_entry(line.as_str());
-                        let split_line: Vec<&str> = line.split(' ').collect();
-                        let repl_subcommand: Result<ReplOpt, clap::Error> =
-                            ReplOpt::from_iter_safe(split_line);
-                        debug!("repl_subcommand = {:?}", repl_subcommand);
+                        let split_line: Vec<&str> =
+                            split_regex.find_iter(&line).map(|m| m.as_str()).collect();
+                        let filtered_line: Vec<&str> = split_line
+                            .iter()
+                            .flat_map(|s| filter_regex.find_iter(s).map(|m| m.as_str()))
+                            .collect();
+                        let repl_opt: Result<ReplOpt, clap::Error> =
+                            ReplOpt::from_iter_safe(filtered_line);
+                        debug!("repl_opt = {:?}", repl_opt);
 
-                        if let Err(err) = repl_subcommand {
+                        if let Err(err) = repl_opt {
                             println!("{}", err.message);
                             continue;
                         }
 
-                        let result = bdk_cli::handle_wallet_subcommand(
-                            &Arc::clone(&wallet),
-                            repl_subcommand.unwrap().subcommand,
-                        )
-                        .unwrap();
-                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        let repl_subcommand = repl_opt.unwrap().subcommand;
+
+                        let result = match repl_subcommand {
+                            ReplSubCommand::OnlineWalletSubCommand(online_subcommand) => {
+                                bdk_cli::handle_online_wallet_subcommand(
+                                    &Arc::clone(&online_wallet),
+                                    online_subcommand,
+                                )
+                            }
+                            ReplSubCommand::OfflineWalletSubCommand(offline_subcommand) => {
+                                bdk_cli::handle_offline_wallet_subcommand(
+                                    &Arc::clone(&offline_wallet),
+                                    offline_subcommand,
+                                )
+                            }
+                            ReplSubCommand::KeySubCommand(key_subcommand) => {
+                                bdk_cli::handle_key_subcommand(network, key_subcommand)
+                            }
+                            ReplSubCommand::Exit => break,
+                        };
+
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&result.unwrap()).unwrap()
+                        );
                     }
                     Err(ReadlineError::Interrupted) => continue,
                     Err(ReadlineError::Eof) => break,
@@ -182,10 +265,34 @@ fn main() {
             }
 
             // rl.save_history("history.txt").unwrap();
+            "Exiting REPL".to_string()
         }
-        _ => {
-            let result = bdk_cli::handle_wallet_subcommand(&wallet, cli_opt.subcommand).unwrap();
-            println!("{}", serde_json::to_string_pretty(&result).unwrap());
-        }
+    };
+
+    println!("{}", result);
+}
+
+#[cfg(test)]
+mod test {
+    use regex::Regex;
+
+    #[test]
+    fn test_regex() {
+        let split_regex = Regex::new(r#"[\w\-]+|"[\w\s]*""#).unwrap();
+        //println!("split_regex = {:?}", &split_regex);
+        let filter_regex = Regex::new(r#"[\w\s\-]+"#).unwrap();
+        //println!("filter_regex = {:?}", &filter_regex);
+        let line = r#"restore -m "word1 word2 word3" -p test"#;
+        let split_line: Vec<&str> = split_regex.find_iter(&line).map(|m| m.as_str()).collect();
+        //println!("split_line({}) = {:?}", &line, &split_line);
+        let filtered_line: Vec<&str> = split_line
+            .iter()
+            .flat_map(|s| filter_regex.find_iter(s).map(|m| m.as_str()))
+            .collect();
+        //println!("filtered_line({:?}) = {:?}", &split_line, &filtered_line);
+        assert_eq!(
+            vec!("restore", "-m", "word1 word2 word3", "-p", "test"),
+            filtered_line
+        );
     }
 }

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -24,7 +24,6 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use bitcoin::Network;
 use clap::AppSettings;
@@ -186,10 +185,6 @@ fn main() {
         CliSubCommand::Repl { wallet_opts } => {
             let database = open_database(&wallet_opts);
             let online_wallet = new_online_wallet(network, &wallet_opts, database.clone()).unwrap();
-            let online_wallet = Arc::new(online_wallet);
-
-            let offline_wallet = new_offline_wallet(network, &wallet_opts, database).unwrap();
-            let offline_wallet = Arc::new(offline_wallet);
 
             let mut rl = Editor::<()>::new();
 
@@ -231,13 +226,13 @@ fn main() {
                         let result = match repl_subcommand {
                             ReplSubCommand::OnlineWalletSubCommand(online_subcommand) => {
                                 bdk_cli::handle_online_wallet_subcommand(
-                                    &Arc::clone(&online_wallet),
+                                    &online_wallet,
                                     online_subcommand,
                                 )
                             }
                             ReplSubCommand::OfflineWalletSubCommand(offline_subcommand) => {
                                 bdk_cli::handle_offline_wallet_subcommand(
-                                    &Arc::clone(&offline_wallet),
+                                    &online_wallet,
                                     offline_subcommand,
                                 )
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,8 +580,8 @@ fn parse_outpoint(s: &str) -> Result<OutPoint, String> {
 ///
 /// Offline wallet sub-commands are described in [`OfflineWalletSubCommand`].
 #[maybe_async]
-pub fn handle_offline_wallet_subcommand<D>(
-    wallet: &Wallet<(), D>,
+pub fn handle_offline_wallet_subcommand<T, D>(
+    wallet: &Wallet<T, D>,
     offline_subcommand: OfflineWalletSubCommand,
 ) -> Result<serde_json::Value, Error>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,52 +331,58 @@ pub struct WalletOpts {
     pub esplora_concurrency: u8,
 }
 
-/// Offline Wallet sub-command
-///
-/// [`CliSubCommand::Wallet`] sub-commands that do not require a blockchain client and network
-/// connection. These sub-commands use only the provided descriptor or locally cached wallet
-/// information.
-///
-/// # Example
-///
-/// ```
-/// # use bdk_cli::OfflineWalletSubCommand;
-/// # use structopt::StructOpt;
-///
-/// let address_sub_command = OfflineWalletSubCommand::from_iter(&["wallet", "get_new_address"]);
-/// assert!(matches!(
-///     address_sub_command,
-///     OfflineWalletSubCommand::GetNewAddress
-/// ));
-/// ```
-///
-/// To capture wallet sub-commands from a string vector without a preceeding binary name you can
-/// create a custom struct the includes the `NoBinaryName` clap setting and wraps the WalletSubCommand
-/// enum. See also the [`bdk-cli`](https://github.com/bitcoindevkit/bdk-cli/blob/master/src/bdkcli.rs)
-/// example app.
-///
-/// # Example
-/// ```
-/// # use bdk_cli::OfflineWalletSubCommand;
-/// # use structopt::StructOpt;
-/// # use clap::AppSettings;
-///
-/// #[derive(Debug, StructOpt, Clone, PartialEq)]
-/// #[structopt(name = "BDK CLI", setting = AppSettings::NoBinaryName,
-/// version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
-/// author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
-/// struct ReplOpts {
-///     /// Wallet sub-command
-///     #[structopt(subcommand)]
-///     pub subcommand: OfflineWalletSubCommand,
-/// }
-///
-/// let repl_opts = ReplOpts::from_iter(&["get_new_address"]);
-/// assert!(matches!(
-///     repl_opts.subcommand,
-///     OfflineWalletSubCommand::GetNewAddress
-/// ));
-/// ```
+// This is a workaround for `structopt` issue #333, #391, #418; see https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(
+    doc,
+    doc = r#"
+Offline Wallet sub-command
+
+[`CliSubCommand::Wallet`] sub-commands that do not require a blockchain client and network
+connection. These sub-commands use only the provided descriptor or locally cached wallet
+information.
+
+# Example
+
+```
+# use bdk_cli::OfflineWalletSubCommand;
+# use structopt::StructOpt;
+
+let address_sub_command = OfflineWalletSubCommand::from_iter(&["wallet", "get_new_address"]);
+assert!(matches!(
+     address_sub_command,
+    OfflineWalletSubCommand::GetNewAddress
+));
+```
+
+To capture wallet sub-commands from a string vector without a preceeding binary name you can
+create a custom struct the includes the `NoBinaryName` clap setting and wraps the WalletSubCommand
+enum. See also the [`bdk-cli`](https://github.com/bitcoindevkit/bdk-cli/blob/master/src/bdkcli.rs)
+example app.
+
+# Example
+```
+# use bdk_cli::OfflineWalletSubCommand;
+# use structopt::StructOpt;
+# use clap::AppSettings;
+
+#[derive(Debug, StructOpt, Clone, PartialEq)]
+#[structopt(name = "BDK CLI", setting = AppSettings::NoBinaryName,
+version = option_env ! ("CARGO_PKG_VERSION").unwrap_or("unknown"),
+author = option_env ! ("CARGO_PKG_AUTHORS").unwrap_or(""))]
+struct ReplOpts {
+    /// Wallet sub-command
+    #[structopt(subcommand)]
+    pub subcommand: OfflineWalletSubCommand,
+}
+
+let repl_opts = ReplOpts::from_iter(&["get_new_address"]);
+assert!(matches!(
+    repl_opts.subcommand,
+    OfflineWalletSubCommand::GetNewAddress
+));
+"#
+)]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 #[structopt(rename_all = "snake")]
 pub enum OfflineWalletSubCommand {
@@ -475,11 +481,17 @@ pub enum OfflineWalletSubCommand {
     },
 }
 
-/// Online Wallet sub-command
-///
-/// [`CliSubCommand::Wallet`] sub-commands that require a blockchain client and network connection.
-/// These sub-commands use a provided descriptor, locally cached wallet information, and require a
-/// blockchain client and network connection.
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(
+    doc,
+    doc = r#"
+Online Wallet sub-command
+
+[`CliSubCommand::Wallet`] sub-commands that require a blockchain client and network connection.
+These sub-commands use a provided descriptor, locally cached wallet information, and require a
+blockchain client and network connection.
+"#
+)]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 #[structopt(rename_all = "snake")]
 pub enum OnlineWalletSubCommand {
@@ -732,13 +744,19 @@ where
     }
 }
 
-/// Key sub-command
-///
-/// Provides basic key operations that are not related to a specific wallet such as generating a
-/// new random master extended key or restoring a master extended key from mnemonic words.
-///
-/// These sub-commands are **EXPERIMENTAL** and should only be used for testing. Do not use this
-/// feature to create keys that secure actual funds on the Bitcoin mainnet.  
+#[cfg_attr(not(doc), allow(missing_docs))]
+#[cfg_attr(
+    doc,
+    doc = r#"
+Key sub-command
+
+Provides basic key operations that are not related to a specific wallet such as generating a
+new random master extended key or restoring a master extended key from mnemonic words.
+
+These sub-commands are **EXPERIMENTAL** and should only be used for testing. Do not use this
+feature to create keys that secure actual funds on the Bitcoin mainnet.  
+"#
+)]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 #[structopt(rename_all = "snake")]
 pub enum KeySubCommand {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,7 +760,7 @@ feature to create keys that secure actual funds on the Bitcoin mainnet.
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 #[structopt(rename_all = "snake")]
 pub enum KeySubCommand {
-    /// Generates new random seed mnemonic phrase and corresponding master extended keys
+    /// Generates new random seed mnemonic phrase and corresponding master extended key
     Generate {
         /// Entropy level based on number of random seed mnemonic words
         #[structopt(
@@ -775,7 +775,7 @@ pub enum KeySubCommand {
         #[structopt(name = "PASSWORD", short = "p", long = "password")]
         password: Option<String>,
     },
-    /// Restore a master extended keys from seed backup mnemonic words
+    /// Restore a master extended key from seed backup mnemonic words
     Restore {
         /// Seed mnemonic words, must be quoted (eg. "word1 word2 ...")
         #[structopt(name = "MNEMONIC", short = "m", long = "mnemonic")]
@@ -804,7 +804,7 @@ pub fn handle_key_subcommand(
                 12 => MnemonicType::Words12,
                 _ => MnemonicType::Words24,
             };
-            let mnemonic: GeneratedKey<_, miniscript::Bare> =
+            let mnemonic: GeneratedKey<_, miniscript::BareCtx> =
                 Mnemonic::generate((mnemonic_type, Language::English)).unwrap();
             //.map_err(|e| KeyError::from(e.unwrap()))?;
             let mnemonic = mnemonic.into_key();


### PR DESCRIPTION
### Description

Depends on https://github.com/bitcoindevkit/bdk/pull/274

Added in Lib
- `CliOpts` struct and `CliSubCommand` enum representing top level cli options and commands
- `KeySubCommand` enum
- `handle_key_subcommand` function

Changed in Lib
- Renamed `WalletOpt` struct to `WalletOpts`
- `WalletSubCommand` enum split into `OfflineWalletSubCommand` and `OnlineWalletSubCommand`
- Split `handle_wallet_subcommand` into two functions, `handle_offline_wallet_subcommand` and `handle_online_wallet_subcommand`
- A wallet without a `Blockchain` is used when handling offline wallet sub-commands

Added in `bdk-cli`
- Top level commands "wallet", "key", and "repl"
- "key" command has sub-commands to "generate" and "restore" a master extended key
- "repl" command now has an "exit" sub-command, fixes #12 

Changed in `bdk-cli`
- "wallet" sub-commands and options must be proceeded by "wallet" command
- "repl" command loop now includes both "wallet" and "key" sub-commands

### Notes to the reviewers

There's a little bug in the help / about info while in REPL mode. ~~I don't think there's a way to work around it but there is a [`structopt` issue] for it.~~ I found a [workaround] for this issue.

[`structopt` issue]: https://github.com/TeXitoi/structopt/issues/391
[workaround]: https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
