### PR TITLE
Add key sub-command to 'derive' xpub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `handle_key_subcommand` function
 
 #### Changed
-- Upgrade BDK to `0.3`
+- Upgrade `bdk` to `0.4.0` and `bdk-macros` to `0.3.0`
 - Renamed `WalletOpt` struct to `WalletOpts`
 - `WalletSubCommand` enum split into `OfflineWalletSubCommand` and `OnlineWalletSubCommand`
 - Split `handle_wallet_subcommand` into two functions, `handle_offline_wallet_subcommand` and `handle_online_wallet_subcommand`
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 - Top level commands "wallet", "key", and "repl"
-- "key" command has sub-commands to "generate" and "restore" a master extended key
+- "key" sub-commands to "generate" and "restore" a master private key
+- "key" sub-command to "derive" an extended public key from a master private key
 - "repl" command now has an "exit" sub-command
 
 #### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179", default-features = false, features = ["all-keys"]}
-bdk-macros = { git = "https://github.com/bitcoindevkit/bdk.git", rev = "c4f2179" }
+bdk = { version = "^0.4", default-features = false, features = ["all-keys"]}
+bdk-macros = "^0.3"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
 log = "^0.4"


### PR DESCRIPTION
### Description

This PR updates dependencies `bdk` to `0.4.0` and `bdk-macros` to `0.3.0` and adds a new `key` `derive` subcommand. The `key` `derive` sub-command derives an xpub from a given master xprv and derivation path.  

The purpose of the `derive` command is to make it easier to create xpubs for use in testing multisig descriptors. For example an xpub can be derived and stored in an environment variable like this:

```shell
echo \"$ALICE_XPRV\"
"tprv8ZgxMBicQKsPfQjJy8ge2cvBfDjLxJSkvNLVQiw7BQ5gTjKadG2rrcQB5zjcdaaUTz5EDNJaS77q4DzjqjogQBfMsaXFFNP3UqoBnwt2kyT"
export ALICE_XPUB=$(bdk-cli key derive --xprv $ALICE_XPRV --path "m/84'/1'/0'/0" | jq -r ".xpub" | sed 's/^\[.*\]//g')
echo \"$ALICE_XPUB\"
"tpubDDrcq8JNTLVwaGnXp7KqZZxFJoic49ikEotWnpm6hpMY2hL2F1hpgbBBkEdsFJHU1iAx9DzMUKYr5mrphBMoXxhsBPhnVdmaoSCaeh6QWgj/0/*"
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
