### PR TITLE
[ci] Manually set rust stable version in CI pipeline

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - 1.50.0 # STABLE
           - 1.45.0 # MSRV
         features:
           - default
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set default toolchain
-        run: rustup default stable
+        run: rustup default 1.50.0 # STABLE
       - name: Set profile
         run: rustup set profile minimal
       - name: Add clippy


### PR DESCRIPTION
### Description

This PR sets the rust stable version in the CI pipeline to 1.50.0. This value will need to be updated manually when a new stable version of Rust :crab:  is released. Any clippy or other fixes required by a new stable version should be fixed in the same PR.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

