### PR TITLE
Add 'compile' sub-command, minor cleanup

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -17,7 +17,8 @@ jobs:
           - repl
           - electrum
           - esplora
-          - repl,electrum,esplora
+          - compiler
+          - repl,electrum,esplora,compiler
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Project
+
+#### Added
+- `CliSubCommand::Compile` enum variant and `handle_compile_subcommand()` function
+
+### `bdk-cli` bin
+
+#### Added
+- New top level command "Compile" which compiles a miniscript policy to an output descriptor
+
 ## [0.2.0]
 
 ### Project

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -182,9 +182,17 @@ fn main() {
             let result = bdk_cli::handle_key_subcommand(network, key_subcommand);
             serde_json::to_string_pretty(&result.unwrap()).unwrap()
         }
+        #[cfg(feature = "compiler")]
+        CliSubCommand::Compile {
+            policy,
+            script_type,
+        } => {
+            let result = bdk_cli::handle_compile_subcommand(network, policy, script_type);
+            serde_json::to_string_pretty(&result.unwrap()).unwrap()
+        }
         CliSubCommand::Repl { wallet_opts } => {
             let database = open_database(&wallet_opts);
-            let online_wallet = new_online_wallet(network, &wallet_opts, database.clone()).unwrap();
+            let online_wallet = new_online_wallet(network, &wallet_opts, database).unwrap();
 
             let mut rl = Editor::<()>::new();
 


### PR DESCRIPTION
### Description

Closes issue #20 

Add to library `CliSubCommand::Compile` enum variant and `handle_compile_subcommand()` function.

Add to `bdk-cli` tool a new top level command "Compile" to compile a miniscript policy to an output descriptor.

Help output:
```
$ cargo run --features=repl,electrum,compiler help compile
...
bdk-cli-compile 0.2.1-dev
Miniscript policy compiler

USAGE:
    bdk-cli compile [OPTIONS] <POLICY>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -t, --type <TYPE>    Sets the script type used to embed the compiled policy [default: wsh]  [possible values: sh,
                         wsh, sh-wsh]

ARGS:
    <POLICY>    Sets the spending policy to compile
```

Example usage:
```
$ cargo run --features=repl,electrum,compiler compile --type sh-wsh "thresh(3,pk($ALICE_XPUB),pk($BOB_XPUB),pk($CAROL_XPUB),older(2))"
...
{
  "descriptor": "sh(wsh(thresh(3,pk([0da98f81/84'/1'/0']tpubDD3Fqx9RKeKUqwGSJpdQTAD1kN1misu4CW4zDNFKPphGJJ5K841B58aGHDFxSo65zDttffmLTSTLgwPPyqRVkhqE6D8JWZzm85K1sZ4A85N/0/*),s:pk([65aac7d2/84'/1'/0']tpubDDmA13CwXYp2ocpSGiiF1YKZK9BVVe9go898of7mYuBfwhmXX3GeYoGMHewk9J1b1xurQFJEQTvc2nSsEmYHwL4wdnNdgXRqvs57DYXjHbp/0/*),s:pk([0b7402df/84'/1'/0']tpubDCJWHKMgzMaT8i8wHzRq73wTmRJMzAyEaRsRBRrQfBxQC949jgkiBw1GqtCFunWVVxkmxs8ZuWt6GrPYrcZyHEDRTnozaxKMGXaAkBtAzTo/0/*),sdv:older(2))))#xmglnxx7"

```

### Notes to the reviewers

This command requires the `compiler` feature be enabled. I didn't add an option to parse the policy since this can already be done with the `wallet policies` sub-command.

I also renamed the cli arg parsing tests.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
