### PR TITLE
Remove unwraps in bdk_cli and more detailed message for ChecksumMismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - `CliSubCommand::Compile` enum variant and `handle_compile_subcommand()` function
 - Make repl and electrum default features
+- Remove unwraps while handling CLI commands
 
 ### `bdk-cli` bin
 


### PR DESCRIPTION
### Description

This removes some unwraps in favor of ? during handling of the commands.

During development I frequently hit ChecksumMismatch while changing the descriptor and keeping the same wallet name, I imagined users may be confused so I detailed the message.

### Notes to the reviewers

On top of #22 

Error handling is a little nicer for end-user but it comes at the expense of losing stacktrace information in case of errors, so it may be controversial. However, we are now writing blog post and expanding user base so I think it is better.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've updated `CHANGELOG.md`

