### PR TITLE
Bump 'bdk' and 'bdk-macros' versions, fix docs.rs build features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-cli"
-version = "0.2.1-dev"
+version = "0.2.1"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>", "Steve Myers <steve@notmandatory.org>"]
 homepage = "https://bitcoindevkit.org"
@@ -40,4 +40,4 @@ path = "src/bdk_cli.rs"
 required-features = ["repl", "electrum"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["esplora", "compiler"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "^0.5", default-features = false, features = ["all-keys"]}
+bdk = { version = "^0.5.1", default-features = false, features = ["all-keys"]}
 bdk-macros = "^0.4"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-cli"
-version = "0.2.1"
+version = "0.2.1-dev"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>", "Steve Myers <steve@notmandatory.org>"]
 homepage = "https://bitcoindevkit.org"
@@ -12,8 +12,8 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "^0.4", default-features = false, features = ["all-keys"]}
-bdk-macros = "^0.3"
+bdk = { version = "^0.5", default-features = false, features = ["all-keys"]}
+bdk-macros = "^0.4"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
 log = "^0.4"


### PR DESCRIPTION
### Description

Preparing for next release with bump to latest `bdk` and `bdk-macros` versions plus fixing docs.rs build features.

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
