### PR TITLE
extended bdk-cli key derive to output xprv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1281,7 +1281,6 @@ mod test {
 
         assert_eq!(&xpub, &"[566844c5/84'/1'/0']tpubDFeqiDkfwR1tAhPxsXSZMfEmfpDhwhLyhLKZgmeBvuBkZQusoWeL62oGg2oTNGcENeKdwuGepAB85eMvyLemabYe9PSqv6cr5mFXktHc3Ka/0/*");
         assert_eq!(&xprv, &"[566844c5/84'/1'/0']tprv8ixoZoiRo3LDHENAysmxxFaf6nhmnNA582inQFbtWdPMivf7B7pjuYBQVuLC5bkM7tJZEDbfoivENsGZPBnQg1n52Kuc1P8X2Ei3XJuJX7c/0/*");
-
     }
 
     #[cfg(feature = "compiler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -831,7 +831,7 @@ pub enum KeySubCommand {
         #[structopt(name = "PASSWORD", short = "p", long = "password")]
         password: Option<String>,
     },
-    /// Derive an xpub from an xprv and a derivation path string (ie. "m/84'/1'/0'/0")
+    /// Derive a child key pair from a master extended key and a derivation path string
     Derive {
         /// Extended private key to derive from
         #[structopt(name = "XPRV", short = "x", long = "xprv")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1268,7 +1268,7 @@ mod test {
     fn test_key_derive() {
         let network = Testnet;
         let key_generate_cmd = KeySubCommand::Derive {
-            xprv: "tprv8ZgxMBicQKsPd18TeiFknZKqaZFwpdX9tvvKh8eeHSSPBQi5g9xPHztBg411o78G8XkrhQb6Q1cVvBJ1a9xuFHpmWgvQsvkJkNxBjfGoqhK"
+            xprv: "tprv8ZgxMBicQKsPfQjJy8ge2cvBfDjLxJSkvNLVQiw7BQ5gTjKadG2rrcQB5zjcdaaUTz5EDNJaS77q4DzjqjogQBfMsaXFFNP3UqoBnwt2kyT"
                 .to_string(),
             path: "m/84'/1'/0'/0".to_string(),
         };
@@ -1279,8 +1279,9 @@ mod test {
         let xpub = result_obj.get("xpub").unwrap().as_str().unwrap();
         let xprv = result_obj.get("xprv").unwrap().as_str().unwrap();
 
-        assert_eq!(&xprv, &"[828af366/84'/1'/0']tprv8hpCmEEuKXVfoJbP7MscEtCaid7ELVQtZACPbNLAECWgeShRJ34rq9b5sfqTRxG6s9qN1d3W1zwvmdDC3umodftA9TzMDWZqXnoBqVtEcsm/0/*");
-        assert_eq!(&xpub, &"[828af366/84'/1'/0']tpubDEWEueH9TuBLgmdB11YCeHrhHedAVpbo8ToAstNTeUK5UvxBvRtT1eCx3q81tj2JcdCV3MumeBW8sGPLXDvEpXivDbE4GW9pVkTXnakXCzS/0/*");
+        assert_eq!(&xpub, &"[566844c5/84'/1'/0']tpubDFeqiDkfwR1tAhPxsXSZMfEmfpDhwhLyhLKZgmeBvuBkZQusoWeL62oGg2oTNGcENeKdwuGepAB85eMvyLemabYe9PSqv6cr5mFXktHc3Ka/0/*");
+        assert_eq!(&xprv, &"[566844c5/84'/1'/0']tprv8ixoZoiRo3LDHENAysmxxFaf6nhmnNA582inQFbtWdPMivf7B7pjuYBQVuLC5bkM7tJZEDbfoivENsGZPBnQg1n52Kuc1P8X2Ei3XJuJX7c/0/*");
+
     }
 
     #[cfg(feature = "compiler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -831,7 +831,7 @@ pub enum KeySubCommand {
         #[structopt(name = "PASSWORD", short = "p", long = "password")]
         password: Option<String>,
     },
-    /// Derive a child key pair from a master extended key and a derivation path string
+    /// Derive a child key pair from a master extended key and a derivation path string (eg. "m/84'/1'/0'/0" or "m/84h/1h/0h/0")
     Derive {
         /// Extended private key to derive from
         #[structopt(name = "XPRV", short = "x", long = "xprv")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,7 +902,7 @@ pub fn handle_key_subcommand(
             let deriv_path_normal =
                 DerivationPath::from(&deriv_path[(deriv_path_len - normal_suffix_len)..]);
 
-            let origin: KeySource = (xprv.fingerprint(&secp).clone(), deriv_path_hardened.clone());
+            let origin: KeySource = (xprv.fingerprint(&secp), deriv_path_hardened);
 
             let derived_xprv_desc_key: DescriptorKey<Segwitv0> =
                 derived_xprv.into_descriptor_key(Some(origin), deriv_path_normal)?;
@@ -1280,7 +1280,7 @@ mod test {
         let xprv = result_obj.get("xprv").unwrap().as_str().unwrap();
 
         assert_eq!(&xprv, &"[828af366/84'/1'/0']tprv8hpCmEEuKXVfoJbP7MscEtCaid7ELVQtZACPbNLAECWgeShRJ34rq9b5sfqTRxG6s9qN1d3W1zwvmdDC3umodftA9TzMDWZqXnoBqVtEcsm/0/*");
-        assert_eq!(&xpub, &"[828af366/84'/1'/0']tpubDEWEueH9TuBLgmdB11YCeHrhHedAVpbo8ToAstNTeUK5UvxBvRtT1eCx3q81tj2JcdCV3MumeBW8sGPLXDvEpXivDbE4GW9pVkTXnakXCzS/0/*");  
+        assert_eq!(&xpub, &"[828af366/84'/1'/0']tpubDEWEueH9TuBLgmdB11YCeHrhHedAVpbo8ToAstNTeUK5UvxBvRtT1eCx3q81tj2JcdCV3MumeBW8sGPLXDvEpXivDbE4GW9pVkTXnakXCzS/0/*");
     }
 
     #[cfg(feature = "compiler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,22 +890,10 @@ pub fn handle_key_subcommand(
             let deriv_path: DerivationPath = DerivationPath::from_str(path.as_str())?;
             let derived_xprv = &xprv.derive_priv(&secp, &deriv_path)?;
 
-            let deriv_path_len = (&deriv_path).as_ref().len();
-            let normal_suffix_len = (&deriv_path)
-                .into_iter()
-                .rev()
-                .take_while(|c| c.is_normal())
-                .count();
-
-            let deriv_path_hardened =
-                DerivationPath::from(&deriv_path[..(deriv_path_len - normal_suffix_len)]);
-            let deriv_path_normal =
-                DerivationPath::from(&deriv_path[(deriv_path_len - normal_suffix_len)..]);
-
-            let origin: KeySource = (xprv.fingerprint(&secp), deriv_path_hardened);
+            let origin: KeySource = (xprv.fingerprint(&secp), deriv_path);
 
             let derived_xprv_desc_key: DescriptorKey<Segwitv0> =
-                derived_xprv.into_descriptor_key(Some(origin), deriv_path_normal)?;
+                derived_xprv.into_descriptor_key(Some(origin), DerivationPath::default())?;
 
             if let Secret(desc_seckey, _, _) = derived_xprv_desc_key {
                 let desc_pubkey = desc_seckey.as_public(&secp).unwrap();
@@ -1279,8 +1267,8 @@ mod test {
         let xpub = result_obj.get("xpub").unwrap().as_str().unwrap();
         let xprv = result_obj.get("xprv").unwrap().as_str().unwrap();
 
-        assert_eq!(&xpub, &"[566844c5/84'/1'/0']tpubDFeqiDkfwR1tAhPxsXSZMfEmfpDhwhLyhLKZgmeBvuBkZQusoWeL62oGg2oTNGcENeKdwuGepAB85eMvyLemabYe9PSqv6cr5mFXktHc3Ka/0/*");
-        assert_eq!(&xprv, &"[566844c5/84'/1'/0']tprv8ixoZoiRo3LDHENAysmxxFaf6nhmnNA582inQFbtWdPMivf7B7pjuYBQVuLC5bkM7tJZEDbfoivENsGZPBnQg1n52Kuc1P8X2Ei3XJuJX7c/0/*");
+        assert_eq!(&xpub, &"[566844c5/84'/1'/0'/0]tpubDFeqiDkfwR1tAhPxsXSZMfEmfpDhwhLyhLKZgmeBvuBkZQusoWeL62oGg2oTNGcENeKdwuGepAB85eMvyLemabYe9PSqv6cr5mFXktHc3Ka/*");
+        assert_eq!(&xprv, &"[566844c5/84'/1'/0'/0]tprv8ixoZoiRo3LDHENAysmxxFaf6nhmnNA582inQFbtWdPMivf7B7pjuYBQVuLC5bkM7tJZEDbfoivENsGZPBnQg1n52Kuc1P8X2Ei3XJuJX7c/*");
     }
 
     #[cfg(feature = "compiler")]


### PR DESCRIPTION
Output:
```
{
  "xprv": "tprv8ZgxMBicQKsPeCmJHoy1pwYwgTyWz2WG1W9MAuqwTFbj7AtiPVdy1C6oZJFMLMyZskVCXsf9XcG2mSVm9twaKkqhKXCh96fbuaPUxBz5Sr4/84'/1'/0'/*",
  "xpub": "[33b0970f/84'/1'/0']tpubDCyioiPrh9dHkBdomkQhvTFeFnKec2XU9a3BM4Z9Y4vVXGWjMj9je3dcV7HjqN21PMH8M98ejEEQwoof8FE4JkD1jqKJhxFwJAxYtAgeieN/*"
}
```
I've been using the same format for xprv as xpub [fingerprint/hardened/path]xprv/*, not sure how to get the xprv in that format - or if it is required.