### PR TITLE
adapt to the changed signing interface in bdk 0.7

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.50.0 # STABLE
-          - 1.45.0 # MSRV
+          - 1.51.0 # STABLE
+          - 1.46.0 # MSRV
         features:
           - default
           - repl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 - `CliSubCommand::Compile` enum variant and `handle_compile_subcommand()` function
+
+#### Changed
 - Make repl and electrum default features
-- Remove unwraps while handling CLI commands
+- Upgrade to `bdk` v0.7.x
 
 ### `bdk-cli` bin
 
 #### Added
 - New top level command "Compile" which compiles a miniscript policy to an output descriptor
 - `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration 
+
+#### Changed
+- Remove unwraps while handling CLI commands
 
 ## [0.2.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "^0.5.1", default-features = false, features = ["all-keys"]}
+bdk = { version = "^0.7", default-features = false, features = ["all-keys"]}
 bdk-macros = "^0.4"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }


### PR DESCRIPTION
### Description

Adapting to the current master branch of bdk.

After the next release of bdk, Cargo.toml, should go back to use crates.io

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
