### PR TITLE
Wallet Verbosity for PSBT details

### DIFF
--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -221,7 +221,11 @@ fn handle_command(cli_opts: CliOpts, network: Network) -> Result<String, Error> 
         } => {
             let database = open_database(&wallet_opts);
             let wallet = new_offline_wallet(network, &wallet_opts, database)?;
-            let result = bdk_cli::handle_offline_wallet_subcommand(&wallet, offline_subcommand)?;
+            let result = bdk_cli::handle_offline_wallet_subcommand(
+                &wallet,
+                &wallet_opts,
+                offline_subcommand,
+            )?;
             serde_json::to_string_pretty(&result)?
         }
         CliSubCommand::Key {
@@ -290,6 +294,7 @@ fn handle_command(cli_opts: CliOpts, network: Network) -> Result<String, Error> 
                             ReplSubCommand::OfflineWalletSubCommand(offline_subcommand) => {
                                 bdk_cli::handle_offline_wallet_subcommand(
                                     &online_wallet,
+                                    &wallet_opts,
                                     offline_subcommand,
                                 )
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 ///             subcommand: CliSubCommand::Wallet {
 ///                 wallet_opts: WalletOpts {
 ///                     wallet: "main".to_string(),
+///                     verbose: false,
 ///                     descriptor: "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)".to_string(),
 ///                     change_descriptor: None,
 ///               #[cfg(feature = "electrum")]
@@ -304,6 +305,7 @@ pub enum WalletSubCommand {
 ///
 /// let expected_wallet_opts = WalletOpts {
 ///               wallet: "main".to_string(),
+///                     verbose: false,
 ///               descriptor: "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)".to_string(),
 ///               change_descriptor: None,
 ///               #[cfg(feature = "electrum")]
@@ -1186,6 +1188,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     #[cfg(feature = "electrum")]
@@ -1238,6 +1241,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     #[cfg(feature = "electrum")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,9 @@ pub struct WalletOpts {
         default_value = "main"
     )]
     pub wallet: String,
+    /// Adds verbosity, returns PSBT in JSON format alongside serialized
+    #[structopt(name = "VERBOSE", short = "v", long = "verbose")]
+    pub verbose: bool,
     /// Sets the descriptor to use for the external addresses
     #[structopt(name = "DESCRIPTOR", short = "d", long = "descriptor", required = true)]
     pub descriptor: String,
@@ -1064,6 +1067,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     #[cfg(feature = "electrum")]
@@ -1113,6 +1117,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     #[cfg(feature = "electrum")]
@@ -1259,6 +1264,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: None,
                     #[cfg(feature = "electrum")]
@@ -1324,6 +1330,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     #[cfg(feature = "electrum")]
@@ -1380,6 +1387,7 @@ mod test {
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
                     wallet: "main".to_string(),
+                    verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: None,
                     #[cfg(feature = "electrum")]


### PR DESCRIPTION
Added "wallet" flag `-v` or `--verbose` for the following offline wallet subcommands: "create_tx", "sign" and "finalize_psbt".

Passed `walletOpts` down to `handle_offline_sub_commands` so that the subcommands can access and know if the verbose flag was set in wallet level.

This PR addresses the issue brought up in #32.