### PR TITLE
Show tx details in case verbose is enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ pub struct WalletOpts {
         default_value = "main"
     )]
     pub wallet: String,
-    /// Adds verbosity, returns PSBT in JSON format alongside serialized
+    /// Adds verbosity, returns PSBT in JSON format alongside serialized, displays expanded objects
     #[structopt(name = "VERBOSE", short = "v", long = "verbose")]
     pub verbose: bool,
     /// Sets the descriptor to use for the external addresses
@@ -702,7 +702,9 @@ where
     match offline_subcommand {
         GetNewAddress => Ok(json!({"address": wallet.get_address(AddressIndex::New)?})),
         ListUnspent => Ok(serde_json::to_value(&wallet.list_unspent()?)?),
-        ListTransactions => Ok(serde_json::to_value(&wallet.list_transactions(false)?)?),
+        ListTransactions => Ok(serde_json::to_value(
+            &wallet.list_transactions(wallet_opts.verbose)?,
+        )?),
         GetBalance => Ok(json!({"satoshi": wallet.get_balance()?})),
         CreateTx {
             recipients,


### PR DESCRIPTION
This adds in verbosity for transactions in `list_transactions`. If verbosity was enabled, it shows the raw transaction as a human readable json.

```bash
❯ ./target/debug/bdk-cli wallet -v -d "wpkh([ece99850/1]tprv8dK67BQwyn6i3gDamn3s5ENnEbAg7DM4FACGygM3wXui4JAWQjUNzuiuNcTh57uFjGQAPrQq22VAxYTyGVnoQt3s4PmBeUHJtt7oJC7wXNk/*)" list_transactions
[
  {
    "fees": 141,
    "height": null,
    "received": 8859,
    "sent": 10000,
    "timestamp": 0,
    "transaction": {
      "input": [
        {
          "previous_output": "6fafe559892e085419596670415826098d85a39f5c707eb5db8cb3e87cab5bbb:1",
          "script_sig": "",
          "sequence": 4294967295,
          "witness": [... redacted due to length ...]
        }
      ],
      "lock_time": 0,
      "output": [
        {
          "script_pubkey": "001471526a6e2a88df813db190190130fdf27bcd6bb9",
          "value": 8859
        },
        {
          "script_pubkey": "0014ff9da567e62f30ea8654fa1d5fbd47bef8e3be13",
          "value": 1000
        }
      ],
      "version": 1
    },
    "txid": "87c9d0cfc131c7582bf29767ccf8acd63da0f519139367dd22fb4e0fb7345ce6"
  }
]
```