### PR TITLE
Add wallet option to select which blockchain client to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,64 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Project
-
-#### Added
-- `CliSubCommand::Compile` enum variant and `handle_compile_subcommand()` function
-
-#### Changed
-- Make repl and electrum default features
+- Update repl feature to not include electrum
 - Upgrade to `bdk` v0.7.x
-
-### `bdk-cli` bin
-
-#### Added
-- New top level command "Compile" which compiles a miniscript policy to an output descriptor
-- `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration 
-
-#### Changed
-- Remove unwraps while handling CLI commands
+- Add top level command "Compile" which compiles a miniscript policy to an output descriptor
+- Add `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration
+- Add `verbose` option to `WalletOpts` to display PSBTs also in JSON format
+- Add `blockchain_client` to `WalletOpts` to select blockchain client to use
 
 ## [0.2.0]
 
-### Project
-
-#### Added
 - Add support for `wasm`
-- `CliOpts` struct and `CliSubCommand` enum representing top level cli options and commands
-- `KeySubCommand` enum
-- `handle_key_subcommand` function
-
-#### Changed
 - Upgrade `bdk` to `0.4.0` and `bdk-macros` to `0.3.0`
-- Renamed `WalletOpt` struct to `WalletOpts`
-- `WalletSubCommand` enum split into `OfflineWalletSubCommand` and `OnlineWalletSubCommand`
-- Split `handle_wallet_subcommand` into two functions, `handle_offline_wallet_subcommand` and `handle_online_wallet_subcommand`
 - A wallet without a `Blockchain` is used when handling offline wallet sub-commands
-
-### `bdk-cli` bin
-
-#### Added
-- Top level commands "wallet", "key", and "repl"
-- "key" sub-commands to "generate" and "restore" a master private key
-- "key" sub-command to "derive" an extended public key from a master private key
+- Add top level commands "wallet", "key", and "repl"
+- Add "key" sub-commands to "generate" and "restore" a master private key
+- Add "key" sub-command to "derive" an extended public key from a master private key
 - "repl" command now has an "exit" sub-command
-
-#### Changed
 - "wallet" sub-commands and options must be proceeded by "wallet" command
 - "repl" command loop now includes both "wallet" and "key" sub-commands
 
 ## [0.1.0]
 
-### Project
-#### Added
 - Add CONTRIBUTING.md
 - Add CI and code coverage Discord badges to the README
 - Add CI and code coverage github actions workflows
 - Add scheduled audit check in CI
 - Add CHANGELOG.md
-
-#### Changed
 - If an invalid network name return an error instead of defaulting to `testnet`
 
 ## [0.1.0-beta.1]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ structopt = "^0.3"
 serde_json = { version = "^1.0" }
 log = "^0.4"
 base64 = "^0.11"
+zeroize = { version = "<1.4.0" }
 
 # Optional dependencies
 rustyline = { version = "6.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,8 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "electrum")]
+/// # {
 /// # use bdk::bitcoin::Network;
 /// # use structopt::StructOpt;
 /// # use bdk_cli::{CliOpts, WalletOpts, CliSubCommand, WalletSubCommand, BlockchainClient};
@@ -168,7 +170,6 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 ///                     descriptor: "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)".to_string(),
 ///                     change_descriptor: None,
 ///                     blockchain_client: BlockchainClient::Electrum,
-///               #[cfg(feature = "electrum")]
 ///               electrum_opts: ElectrumOpts {
 ///                   timeout: None,
 ///                   electrum: "ssl://electrum.blockstream.info:60002".to_string(),
@@ -184,7 +185,6 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 ///                    conn_count: 4,
 ///                    skip_blocks: 0,
 ///                },
-///                #[cfg(any(feature="compact_filters", feature="electrum"))]
 ///                    proxy_opts: ProxyOpts{
 ///                        proxy: None,
 ///                        proxy_auth: None,
@@ -198,6 +198,7 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 ///         };
 ///
 /// assert_eq!(expected_cli_opts, cli_opts);
+/// # }
 /// ```
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 #[structopt(name = "BDK CLI",
@@ -284,6 +285,8 @@ pub enum WalletSubCommand {
 /// # Example
 ///
 /// ```
+/// # #[cfg(feature = "electrum")]
+/// # {
 /// # use bdk::bitcoin::Network;
 /// # use structopt::StructOpt;
 /// # use bdk_cli::{WalletOpts, BlockchainClient};
@@ -310,7 +313,6 @@ pub enum WalletSubCommand {
 ///               descriptor: "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)".to_string(),
 ///               change_descriptor: None,
 ///               blockchain_client: BlockchainClient::Electrum,
-///               #[cfg(feature = "electrum")]
 ///               electrum_opts: ElectrumOpts {
 ///                   timeout: None,
 ///                   electrum: "ssl://electrum.blockstream.info:60002".to_string(),
@@ -326,7 +328,6 @@ pub enum WalletSubCommand {
 ///                    conn_count: 4,
 ///                    skip_blocks: 0,
 ///                },
-///               #[cfg(any(feature="compact_filters", feature="electrum"))]
 ///                    proxy_opts: ProxyOpts{
 ///                        proxy: None,
 ///                        proxy_auth: None,
@@ -335,6 +336,7 @@ pub enum WalletSubCommand {
 /// };
 ///
 /// assert_eq!(expected_wallet_opts, wallet_opts);
+/// # }
 /// ```
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 pub struct WalletOpts {
@@ -363,6 +365,7 @@ pub struct WalletOpts {
         possible_values = &["electrum", "esplora", "compact_filters"],
         parse(try_from_str = parse_blockchain_client),
     )]
+    #[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
     pub blockchain_client: BlockchainClient,
     #[cfg(feature = "electrum")]
     #[structopt(flatten)]
@@ -1131,6 +1134,7 @@ mod test {
     use std::str::FromStr;
     use structopt::StructOpt;
 
+    #[cfg(feature = "electrum")]
     #[test]
     fn test_parse_wallet_get_new_address() {
         let cli_args = vec!["bdk-cli", "--network", "bitcoin", "wallet",
@@ -1286,7 +1290,8 @@ mod test {
     fn test_parse_wallet_compact_filters() {
         let cli_args = vec!["bdk-cli", "--network", "bitcoin", "wallet",
                             "--descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)",
-                            "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",             
+                            "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
+                            "--blockchain_client", "compact_filters",
                             "--proxy", "127.0.0.1:9005",
                             "--proxy_auth", "random_user:random_passwd",
                             "--node", "127.0.0.1:18444", "127.2.3.1:19695",
@@ -1304,7 +1309,7 @@ mod test {
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
-                    blockchain_client: BlockchainClient::Electrum,
+                    blockchain_client: BlockchainClient::CompactFilters,
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
@@ -1335,6 +1340,7 @@ mod test {
         assert_eq!(expected_cli_opts, cli_opts);
     }
 
+    #[cfg(feature = "electrum")]
     #[test]
     fn test_parse_wallet_sync() {
         let cli_args = vec!["bdk-cli", "--network", "testnet", "wallet",
@@ -1384,6 +1390,7 @@ mod test {
         assert_eq!(expected_cli_opts, cli_opts);
     }
 
+    #[cfg(feature = "electrum")]
     #[test]
     fn test_parse_wallet_create_tx() {
         let cli_args = vec!["bdk-cli", "--network", "testnet", "wallet",
@@ -1459,6 +1466,7 @@ mod test {
         assert_eq!(expected_cli_opts, cli_opts);
     }
 
+    #[cfg(feature = "electrum")]
     #[test]
     fn test_parse_wallet_broadcast() {
         let cli_args = vec!["bdk-cli", "--network", "testnet", "wallet",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@ fn parse_blockchain_client(s: &str) -> Result<BlockchainClient, String> {
 #[cfg(any(feature = "compact_filters", feature = "electrum"))]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 pub struct ProxyOpts {
-    /// Blockchain client SOCKS5 proxy 
+    /// Blockchain client SOCKS5 proxy
     #[structopt(name = "PROXY_ADDRS:PORT", long = "proxy", short = "p")]
     pub proxy: Option<String>,
 
@@ -495,7 +495,7 @@ pub struct EsploraOpts {
         default_value = "https://blockstream.info/api/"
     )]
     pub esplora: String,
-    /// Esplora blockchain client request concurrency 
+    /// Esplora blockchain client request concurrency
     #[structopt(
         name = "ESPLORA_CONCURRENCY",
         long = "esplora_concurrency",
@@ -1111,7 +1111,7 @@ pub fn handle_compile_subcommand(
 
 #[cfg(test)]
 mod test {
-    use super::{CliOpts, WalletOpts, BlockchainClient};
+    use super::{BlockchainClient, CliOpts, WalletOpts};
     #[cfg(feature = "compiler")]
     use crate::handle_compile_subcommand;
     #[cfg(feature = "compact_filters")]


### PR DESCRIPTION
### Description

Added the `--blockchain_client` or `-b` wallet option so the user can explicitly select which blockchain client to use if multiple are available in the build. This will make adding new blockchain clients (such as #36) easier. Currently `electrum` is the default.
I also added a default esplora server url so the user doesn't need to specify one if selecting that client, which is how the electrum and compact_filters clients work.

The new wallet options looks like this (when all optional clients are enabled `--features esplora,compact_filters`):
```
bdk-cli-wallet 0.2.1-dev
Wallet mode

USAGE:
    bdk-cli wallet [FLAGS] [OPTIONS] --descriptor <DESCRIPTOR> <SUBCOMMAND>

FLAGS:
    -v, --verbose    Adds verbosity, returns PSBT in JSON format alongside serialized
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -n, --node <ADDRESS:PORT>...
            Compact filters blockchain client peer full node IP address:port [default: 127.0.0.1:18444]

    -b, --blockchain_client <BLOCKCHAIN_CLIENT>
            Blockchain client protocol [default: electrum]  [possible values: electrum, esplora, compact_filters]

    -c, --change_descriptor <CHANGE_DESCRIPTOR>        Sets the descriptor to use for internal addresses
        --conn_count <CONNECTIONS>
            Compact filters blockchain client number of parallel node connections [default: 4]

    -d, --descriptor <DESCRIPTOR>                      Sets the descriptor to use for the external addresses
        --esplora_concurrency <ESPLORA_CONCURRENCY>    Esplora blockchain client request concurrency [default: 4]
    -e, --esplora <ESPLORA_URL>
            Esplora blockchain client server url [default: https://blockstream.info/api/]

    -p, --proxy <PROXY_ADDRS:PORT>                     Blockchain client SOCKS5 proxy
    -r, --retries <PROXY_RETRIES>                      Blockchain client SOCKS5 proxy retries [default: 5]
    -t, --timeout <PROXY_TIMEOUT>                      Electrum blockchain client SOCKS5 proxy timeout
    -a, --proxy_auth <PROXY_USER:PASSWD>               Blockchain client SOCKS5 proxy credential
    -s, --server <SERVER:PORT>
            Electrum blockchain client server url [default: ssl://electrum.blockstream.info:60002]

    -k, --skip_blocks <SKIP_BLOCKS>
            Compact filters blockchain client skip initial blocks [default: 0]

    -w, --wallet <WALLET_NAME>                         Selects the wallet to use [default: main]
```

### Notes to the reviewers

In the docs for the `blockchain_client` option it displays the default `[electrum]` even if that feature is not enabled and all possible blockchain clients are displayed even if only some are enabled. I couldn't find a nice way to fix this, but the cli will throw an error if a blockchain client is selected that wasn't configured as a feature in the build.

I also simplified the CHANGELOG to focus on what a user would see as a change while using the bin.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
