### PR TITLE
Allow enabling at most one blockchain client feature

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -19,7 +19,6 @@ jobs:
           - esplora
           - compiler
           - compact_filters
-          - repl,electrum,esplora,compiler
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -14,7 +14,6 @@ jobs:
           - 1.46.0 # MSRV
         features:
           - default
-          - repl
           - electrum
           - esplora
           - compiler
@@ -40,11 +39,11 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Build
-        run: cargo build --features ${{ matrix.features }} --no-default-features --locked
+        run: cargo build --features ${{ matrix.features }} --locked
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: Test
-        run: cargo test --features ${{ matrix.features }} --no-default-features
+        run: cargo test --features ${{ matrix.features }}
 
   fmt:
     name: Rust fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to `bdk` v0.7.x
 - Add top level command "Compile" which compiles a miniscript policy to an output descriptor
 - Add `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration
-- Add `verbose` option to `WalletOpts` to display PSBTs also in JSON format
+- Add `verbose` option to `WalletOpts` to display PSBTs and transaction details also in JSON format
 - Require at most one blockchain client feature be enabled at a time
 
 ## [0.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Update repl feature to not include electrum
+- Update default feature to not include electrum
 - Upgrade to `bdk` v0.7.x
 - Add top level command "Compile" which compiles a miniscript policy to an output descriptor
 - Add `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,64 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Project
-
-#### Added
-- `CliSubCommand::Compile` enum variant and `handle_compile_subcommand()` function
-
-#### Changed
-- Make repl and electrum default features
+- Update repl feature to not include electrum
 - Upgrade to `bdk` v0.7.x
-
-### `bdk-cli` bin
-
-#### Added
-- New top level command "Compile" which compiles a miniscript policy to an output descriptor
-- `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration 
-
-#### Changed
-- Remove unwraps while handling CLI commands
+- Add top level command "Compile" which compiles a miniscript policy to an output descriptor
+- Add `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration
+- Add `verbose` option to `WalletOpts` to display PSBTs also in JSON format
+- Require at most one blockchain client feature be enabled at a time
 
 ## [0.2.0]
 
-### Project
-
-#### Added
 - Add support for `wasm`
-- `CliOpts` struct and `CliSubCommand` enum representing top level cli options and commands
-- `KeySubCommand` enum
-- `handle_key_subcommand` function
-
-#### Changed
 - Upgrade `bdk` to `0.4.0` and `bdk-macros` to `0.3.0`
-- Renamed `WalletOpt` struct to `WalletOpts`
-- `WalletSubCommand` enum split into `OfflineWalletSubCommand` and `OnlineWalletSubCommand`
-- Split `handle_wallet_subcommand` into two functions, `handle_offline_wallet_subcommand` and `handle_online_wallet_subcommand`
 - A wallet without a `Blockchain` is used when handling offline wallet sub-commands
-
-### `bdk-cli` bin
-
-#### Added
-- Top level commands "wallet", "key", and "repl"
-- "key" sub-commands to "generate" and "restore" a master private key
-- "key" sub-command to "derive" an extended public key from a master private key
+- Add top level commands "wallet", "key", and "repl"
+- Add "key" sub-commands to "generate" and "restore" a master private key
+- Add "key" sub-command to "derive" an extended public key from a master private key
 - "repl" command now has an "exit" sub-command
-
-#### Changed
 - "wallet" sub-commands and options must be proceeded by "wallet" command
 - "repl" command loop now includes both "wallet" and "key" sub-commands
 
 ## [0.1.0]
 
-### Project
-#### Added
 - Add CONTRIBUTING.md
 - Add CI and code coverage Discord badges to the README
 - Add CI and code coverage github actions workflows
 - Add scheduled audit check in CI
 - Add CHANGELOG.md
-
-#### Changed
 - If an invalid network name return an error instead of defaulting to `testnet`
 
 ## [0.1.0-beta.1]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "rustyline",
  "serde_json",
  "structopt",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -28,9 +28,9 @@ checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -139,9 +139,9 @@ checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
 name = "bindgen"
-version = "0.57.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+checksum = "453c49e5950bb0eb63bb3df640e31618846c89d5b7faa54040d76e98e0134375"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -179,9 +179,21 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -221,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+checksum = "db507a7679252d2276ed0dd8113c6875ec56d3089f9225b2b42c30cc1f8e5c89"
 dependencies = [
  "nom",
 ]
@@ -453,10 +465,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.15"
+name = "funty"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "futures"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -469,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -479,15 +497,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -496,15 +514,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -515,21 +533,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -661,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes",
  "http",
@@ -693,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -772,18 +790,18 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -802,9 +820,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libloading"
@@ -818,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.17.3"
+version = "6.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da125e1c0f22c7cae785982115523a0738728498547f415c9054cb17c7e89f9"
+checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
 dependencies = [
  "bindgen",
  "cc",
@@ -854,9 +872,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -906,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -936,10 +954,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
+ "bitvec",
+ "funty",
  "memchr",
  "version_check",
 ]
@@ -1109,9 +1129,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1130,6 +1150,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1214,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -1233,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1431,18 +1457,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1451,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -1487,15 +1513,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "sled"
@@ -1521,9 +1547,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1585,9 +1611,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1605,6 +1631,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1678,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1693,9 +1725,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1870,9 +1902,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1882,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1897,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1909,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1919,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1932,15 +1964,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2026,6 +2058,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ compact_filters = ["bdk/compact_filters"]
 [[bin]]
 name = "bdk-cli"
 path = "src/bdk_cli.rs"
-required-features = ["repl", "electrum"]
+required-features = ["repl"]
 
 [package.metadata.docs.rs]
-features = ["esplora", "compiler"]
+features = ["compiler"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ clap = { version = "2.33", optional = true }
 regex = {version = "1", optional = true }
 
 [features]
-default = ["repl", "electrum"]
-repl = ["bdk/key-value-db", "clap", "dirs-next", "env_logger", "regex", "rustyline"]
+default = ["cli", "repl"]
+cli = ["bdk/key-value-db", "clap", "dirs-next", "env_logger"]
+repl = ["regex", "rustyline"]
 electrum = ["bdk/electrum"]
 esplora = ["bdk/esplora"]
 compiler = ["bdk/compiler"]
@@ -39,7 +40,7 @@ compact_filters = ["bdk/compact_filters"]
 [[bin]]
 name = "bdk-cli"
 path = "src/bdk_cli.rs"
-required-features = ["repl"]
+required-features = ["cli"]
 
 [package.metadata.docs.rs]
 features = ["compiler"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ path = "src/bdk_cli.rs"
 required-features = ["cli"]
 
 [package.metadata.docs.rs]
-features = ["compiler"]
+features = ["compiler", "electrum"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ structopt = "^0.3"
 serde_json = { version = "^1.0" }
 log = "^0.4"
 base64 = "^0.11"
+zeroize = { version = "<1.4.0" }
 
 # Optional dependencies
 rustyline = { version = "6.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -10,28 +10,31 @@ wallet tool based on the [bdk](https://github.com/bitcoindevkit/bdk) library.
 
 ## Install bdk-cli
 ### From source
-To install dev version of `bdk-cli` from local git repo:
+To install dev version of `bdk-cli` from local git repo with the `electrum` blockchain client enabled:
 
 ```shell
 cd <bdk-cli git repo directory>
-cargo install --path .
+cargo install --path . --features electrum
 bdk-cli help # to verify it worked
 ```
 
-By default the `electrum` client feature is enabled, to use the `esplora` or another blockchain backend
-client instead the default features must be disabled and the desired client feature enabled. Below
-is an example of how to enable the `esplora` blockchain client feature instead of `electrum`.
+If no blockchain client feature is enabled online wallet commands `sync` and `broadcast` will be 
+disabled. To enable these commands a blockchain client features such as `electrum` or another 
+blockchain backend feature must be enabled. Below is an example of how run the `bdk-cli` bin with 
+the `esplora` blockchain client feature.
 
 ```shell
-RUST_LOG=debug cargo run --no-default-features --features repl,esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+RUST_LOG=debug cargo run --features esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
-If no blockchain client feature is enabled then online wallet commands are disabled.
+At most one blockchain feature can be enabled, available blockchain client features are:
+`electrum`, `esplora`, and `compact_filters`.
 
 ### From crates.io
-You can the install the binaries for the latest tag of `bdk-cli` directly from [crates.io](https://crates.io/crates/bdk-cli) like so:
+You can the install the binaries for the latest tag of `bdk-cli` with online wallet features 
+directly from [crates.io](https://crates.io/crates/bdk-cli) with a command as below:
 ```sh
-cargo install bdk-cli 
+cargo install bdk-cli --features `electrum`
 ```
 
 ### bdk-cli bin usage examples
@@ -46,7 +49,7 @@ cargo run
 To sync a wallet to the default electrum server:
 
 ```shell
-cargo run -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+cargo run --features electrum -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
 To sync a wallet to Bitcoin Core node (assuming a regtest node at 127.0.0.1:18444) serving compact filters:
@@ -55,7 +58,7 @@ Note:
 - Bitcoin Core v0.21.0 or higher is required to serve compact filters.  
 
 ```shell
-cargo run --no-default-features --features repl,compact_filters -- --network regtest wallet --node 127.0.0.1:18444 --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+cargo run --features compact_filters -- --network regtest wallet --node 127.0.0.1:18444 --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
 To get a wallet balance with customized logging:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ At most one blockchain feature can be enabled, available blockchain client featu
 You can the install the binaries for the latest tag of `bdk-cli` with online wallet features 
 directly from [crates.io](https://crates.io/crates/bdk-cli) with a command as below:
 ```sh
-cargo install bdk-cli --features `electrum`
+cargo install bdk-cli --features electrum
 ```
 
 ### bdk-cli bin usage examples

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ is an example of how to enable the `esplora` blockchain client feature instead o
 RUST_LOG=debug cargo run --no-default-features --features repl,esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
-If no blockchain client features are enabled then online wallet commands are disabled.
+If no blockchain client feature is enabled then online wallet commands are disabled.
 
 ### From crates.io
 You can the install the binaries for the latest tag of `bdk-cli` directly from [crates.io](https://crates.io/crates/bdk-cli) like so:

--- a/README.md
+++ b/README.md
@@ -18,16 +18,20 @@ cargo install --path .
 bdk-cli help # to verify it worked
 ```
 
-By default an electrum backend is used, to use esplora instead the relative feature must be enabled and the esplora address must be specified. Note we are enabling logs to see the calls to esplora.
+By default the `electrum` client feature is enabled, to use the `esplora` or another blockchain backend
+client instead the default features must be disabled and the desired client feature enabled. Below
+is an example of how to enable the `esplora` blockchain client feature instead of `electrum`.
 
 ```shell
-RUST_LOG=debug cargo run --features esplora -- wallet -e https://blockstream.info/api/ --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+RUST_LOG=debug cargo run --no-default-features --features repl,esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
+
+If no blockchain client features are enabled then online wallet commands are disabled.
 
 ### From crates.io
 You can the install the binaries for the latest tag of `bdk-cli` directly from [crates.io](https://crates.io/crates/bdk-cli) like so:
 ```sh
-cargo install bdk-cli --features repl,electrum,esplora
+cargo install bdk-cli 
 ```
 
 ### bdk-cli bin usage examples
@@ -51,7 +55,7 @@ Note:
 - Bitcoin Core v0.21.0 or higher is required to serve compact filters.  
 
 ```shell
-cargo run --features compact_filters -- --network regtest wallet --node 127.0.0.1:18444 --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+cargo run --no-default-features --features repl,compact_filters -- --network regtest wallet --node 127.0.0.1:18444 --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
 To get a wallet balance with customized logging:

--- a/build.rs
+++ b/build.rs
@@ -3,14 +3,15 @@ use std::env;
 fn main() {
     let electrum = env::var_os("CARGO_FEATURE_ELECTRUM").map(|_| "electrum".to_string());
     let esplora = env::var_os("CARGO_FEATURE_ESPLORA").map(|_| "esplora".to_string());
-    let compact_filters = env::var_os("CARGO_FEATURE_COMPACT_FILTERS").map(|_| "compact_filters".to_string());
+    let compact_filters =
+        env::var_os("CARGO_FEATURE_COMPACT_FILTERS").map(|_| "compact_filters".to_string());
 
-    let blockchain_features : Vec<String> = vec!(electrum, esplora, compact_filters)
+    let blockchain_features: Vec<String> = vec![electrum, esplora, compact_filters]
         .iter()
         .map(|f| f.to_owned())
         .flatten()
         .collect();
-    
+
     if blockchain_features.len() > 1 {
         panic!("At most one blockchain client feature can be enabled but these features were enabled: {:?}", blockchain_features)
     }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+
+fn main() {
+    let electrum = env::var_os("CARGO_FEATURE_ELECTRUM").map(|_| "electrum".to_string());
+    let esplora = env::var_os("CARGO_FEATURE_ESPLORA").map(|_| "esplora".to_string());
+    let compact_filters = env::var_os("CARGO_FEATURE_COMPACT_FILTERS").map(|_| "compact_filters".to_string());
+
+    let blockchain_features : Vec<String> = vec!(electrum, esplora, compact_filters)
+        .iter()
+        .map(|f| f.to_owned())
+        .flatten()
+        .collect();
+    
+    if blockchain_features.len() > 1 {
+        panic!("At most one blockchain client feature can be enabled but these features were enabled: {:?}", blockchain_features)
+    }
+}

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -28,8 +28,12 @@ use std::path::PathBuf;
 use bitcoin::Network;
 use clap::AppSettings;
 use log::{debug, error, info, warn};
+
+#[cfg(feature = "repl")]
 use rustyline::error::ReadlineError;
+#[cfg(feature = "repl")]
 use rustyline::Editor;
+
 use structopt::StructOpt;
 
 #[cfg(feature = "compact_filters")]
@@ -53,8 +57,10 @@ use bdk_cli::{CliOpts, CliSubCommand, KeySubCommand, OfflineWalletSubCommand, Wa
 #[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 use bdk_cli::OnlineWalletSubCommand;
 
+#[cfg(feature = "repl")]
 use regex::Regex;
 
+#[cfg(feature = "repl")]
 const REPL_LINE_SPLIT_REGEX: &str = r#""([^"]*)"|'([^']*)'|([\w\-]+)"#;
 
 /// REPL mode
@@ -251,6 +257,7 @@ fn handle_command(cli_opts: CliOpts, network: Network) -> Result<String, Error> 
             let result = bdk_cli::handle_compile_subcommand(network, policy, script_type)?;
             serde_json::to_string_pretty(&result)?
         }
+        #[cfg(feature = "repl")]
         CliSubCommand::Repl { wallet_opts } => {
             let database = open_database(&wallet_opts);
 

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -116,12 +116,6 @@ fn new_online_wallet<D>(
 where
     D: BatchDatabase,
 {
-    #[cfg(all(
-        feature = "electrum",
-        any(feature = "esplora", feature = "compact_filters")
-    ))]
-    compile_error!("Only one blockchain client feature can be enabled at a time.");
-
     #[cfg(feature = "electrum")]
     let config = AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
         url: wallet_opts.electrum_opts.electrum.clone(),
@@ -130,23 +124,11 @@ where
         timeout: wallet_opts.electrum_opts.timeout,
     });
 
-    #[cfg(all(
-        feature = "esplora",
-        any(feature = "electrum", feature = "compact_filters")
-    ))]
-    compile_error!("Only one blockchain client feature can be enabled at a time.");
-
     #[cfg(feature = "esplora")]
     let config = AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
         base_url: wallet_opts.esplora_opts.server.clone(),
         concurrency: Some(wallet_opts.esplora_opts.concurrency),
     });
-
-    #[cfg(all(
-        feature = "compact_filters",
-        any(feature = "electrum", feature = "esplora")
-    ))]
-    compile_error!("Only one blockchain client feature can be enabled at a time.");
 
     #[cfg(feature = "compact_filters")]
     let config = {

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -118,7 +118,7 @@ where
 {
     #[cfg(feature = "electrum")]
     let config = AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
-        url: wallet_opts.electrum_opts.electrum.clone(),
+        url: wallet_opts.electrum_opts.server.clone(),
         socks5: wallet_opts.proxy_opts.proxy.clone(),
         retry: wallet_opts.proxy_opts.retries,
         timeout: wallet_opts.electrum_opts.timeout,

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -114,7 +114,7 @@ where
         feature = "electrum",
         any(feature = "esplora", feature = "compact_filters")
     ))]
-    compile_error!("Only one blockchain client feature can be enabled at a time. The 'electrum' feature can not be enabled with 'esplora' or 'compact_filters'.");
+    compile_error!("Only one blockchain client feature can be enabled at a time.");
 
     #[cfg(feature = "electrum")]
     let config = AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
@@ -128,7 +128,7 @@ where
         feature = "esplora",
         any(feature = "electrum", feature = "compact_filters")
     ))]
-    compile_error!("Only one blockchain client feature can be enabled at a time. The 'esplora' feature can not be enabled with 'electrum' or 'compact_filters'.");
+    compile_error!("Only one blockchain client feature can be enabled at a time.");
 
     #[cfg(feature = "esplora")]
     let config = AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
@@ -140,7 +140,7 @@ where
         feature = "compact_filters",
         any(feature = "electrum", feature = "esplora")
     ))]
-    compile_error!("Only one blockchain client feature can be enabled at a time. The 'esplora' feature can not be enabled with 'electrum' or 'compact_filters'.");
+    compile_error!("Only one blockchain client feature can be enabled at a time.");
 
     #[cfg(feature = "compact_filters")]
     let config = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,7 @@ pub enum CliSubCommand {
         script_type: String,
     },
     /// Enter REPL command loop mode
+    #[cfg(feature = "repl")]
     #[structopt(long_about = "REPL command loop mode")]
     Repl {
         #[structopt(flatten)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,16 @@ pub use structopt;
 use structopt::StructOpt;
 
 use crate::OfflineWalletSubCommand::*;
+#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 use crate::OnlineWalletSubCommand::*;
 use bdk::bitcoin::consensus::encode::{deserialize, serialize, serialize_hex};
+#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 use bdk::bitcoin::hashes::hex::FromHex;
 use bdk::bitcoin::secp256k1::Secp256k1;
 use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, KeySource};
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::{Address, Network, OutPoint, Script, Txid};
+#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 use bdk::blockchain::{log_progress, Blockchain};
 use bdk::database::BatchDatabase;
 use bdk::descriptor::Segwitv0;
@@ -635,6 +638,7 @@ blockchain client and network connection.
 )]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 #[structopt(rename_all = "snake")]
+#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 pub enum OnlineWalletSubCommand {
     /// Syncs with the chosen blockchain server
     Sync {
@@ -890,6 +894,7 @@ where
 ///
 /// Online wallet sub-commands are described in [`OnlineWalletSubCommand`]. See [`crate`] for
 /// example usage.
+#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 #[maybe_async]
 pub fn handle_online_wallet_subcommand<C, D>(
     wallet: &Wallet<C, D>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! This lib provides [`structopt`] structs and enums that parse CLI options and sub-commands from
 //! the command line or from a `String` vector that can be used to access features of the [`bdk`]
 //! library. Functions are also provided to handle subcommands and options and provide results via
-//! the [`bdk`] lib.  
+//! the [`bdk`] lib.
 //!
 //! See the [`bdk-cli`] example bin for how to use this lib to create a simple command line
 //! application that demonstrates [`bdk`] wallet and key management features.
@@ -74,7 +74,7 @@
 //!     let database = MemoryDatabase::new();
 //!
 //!     let config = AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
-//!                 url: wallet_opts.electrum_opts.electrum,
+//!                 url: wallet_opts.electrum_opts.server,
 //!                 socks5: wallet_opts.proxy_opts.proxy,
 //!                 retry: wallet_opts.proxy_opts.retries,
 //!                 timeout: None,
@@ -177,10 +177,10 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 ///               #[cfg(feature = "electrum")]
 ///               electrum_opts: ElectrumOpts {
 ///                   timeout: None,
-///                   electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+///                   server: "ssl://electrum.blockstream.info:60002".to_string(),
 ///               },
 ///               #[cfg(feature = "esplora")]
-///               esplora_opts: EsploraOpts {               
+///               esplora_opts: EsploraOpts {
 ///                   server: "https://blockstream.info/api/".to_string(),
 ///                   concurrency: 4,
 ///               },
@@ -288,7 +288,7 @@ pub enum WalletSubCommand {
 ///
 /// The wallet options required for all [`CliSubCommand::Wallet`] or [`CliSubCommand::Repl`]
 /// sub-commands. These options capture wallet descriptor and blockchain client information. The
-/// blockchain client details are only used for [`OnlineWalletSubCommand`]s.   
+/// blockchain client details are only used for [`OnlineWalletSubCommand`]s.
 ///
 /// # Example
 ///
@@ -321,10 +321,10 @@ pub enum WalletSubCommand {
 ///               #[cfg(feature = "electrum")]
 ///               electrum_opts: ElectrumOpts {
 ///                   timeout: None,
-///                   electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+///                   server: "ssl://electrum.blockstream.info:60002".to_string(),
 ///               },
 ///               #[cfg(feature = "esplora")]
-///               esplora_opts: EsploraOpts {               
+///               esplora_opts: EsploraOpts {
 ///                   server: "https://blockstream.info/api/".to_string(),
 ///                   concurrency: 4,
 ///               },
@@ -446,7 +446,7 @@ pub struct ElectrumOpts {
         long = "server",
         default_value = "ssl://electrum.blockstream.info:60002"
     )]
-    pub electrum: String,
+    pub server: String,
 }
 
 /// Esplora options
@@ -939,7 +939,7 @@ Provides basic key operations that are not related to a specific wallet such as 
 new random master extended key or restoring a master extended key from mnemonic words.
 
 These sub-commands are **EXPERIMENTAL** and should only be used for testing. Do not use this
-feature to create keys that secure actual funds on the Bitcoin mainnet.  
+feature to create keys that secure actual funds on the Bitcoin mainnet.
 "#
 )]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
@@ -1114,7 +1114,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
-                        electrum: "ssl://electrum.blockstream.info:60002".to_string()
+                        server: "ssl://electrum.blockstream.info:60002".to_string()
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
@@ -1164,7 +1164,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: Some(10),
-                        electrum: "ssl://electrum.blockstream.info:50002".to_string(),
+                        server: "ssl://electrum.blockstream.info:50002".to_string(),
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
@@ -1196,7 +1196,7 @@ mod test {
     fn test_parse_wallet_esplora() {
         let cli_args = vec!["bdk-cli", "--network", "bitcoin", "wallet",
                             "--descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)",
-                            "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",             
+                            "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
                             "--server", "https://blockstream.info/api/",
                             "--concurrency", "5",
                             "get_new_address"];
@@ -1214,7 +1214,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
-                        electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+                        server: "ssl://electrum.blockstream.info:60002".to_string(),
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
@@ -1246,7 +1246,7 @@ mod test {
     fn test_parse_wallet_compact_filters() {
         let cli_args = vec!["bdk-cli", "--network", "bitcoin", "wallet",
                             "--descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)",
-                            "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",             
+                            "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
                             "--proxy", "127.0.0.1:9005",
                             "--proxy_auth", "random_user:random_passwd",
                             "--node", "127.0.0.1:18444", "127.2.3.1:19695",
@@ -1267,7 +1267,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
-                        electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+                        server: "ssl://electrum.blockstream.info:60002".to_string(),
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
@@ -1314,7 +1314,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
-                        electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+                        server: "ssl://electrum.blockstream.info:60002".to_string(),
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
@@ -1380,7 +1380,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
-                        electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+                        server: "ssl://electrum.blockstream.info:60002".to_string(),
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
@@ -1438,7 +1438,7 @@ mod test {
                     #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: None,
-                        electrum: "ssl://electrum.blockstream.info:60002".to_string(),
+                        server: "ssl://electrum.blockstream.info:60002".to_string(),
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@
 pub extern crate bdk;
 #[macro_use]
 extern crate serde_json;
+
+#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
 #[macro_use]
 extern crate bdk_macros;
 
@@ -673,11 +675,11 @@ fn parse_recipient(s: &str) -> Result<(Script, u64), String> {
         return Err("Invalid format".to_string());
     }
 
-    let addr = Address::from_str(&parts[0]);
+    let addr = Address::from_str(parts[0]);
     if let Err(e) = addr {
         return Err(format!("{:?}", e));
     }
-    let val = u64::from_str(&parts[1]);
+    let val = u64::from_str(parts[1]);
     if let Err(e) = val {
         return Err(format!("{:?}", e));
     }


### PR DESCRIPTION
### Description

Allow at most one blockchain client feature be enabled at a time for builds. If no blockchain client feature is enabled then online wallet commands are disabled. This will simplify the options shown to the user and make adding new blockchain clients (such as #36) easier. ~~Electrum is still the default, to make a build with a different blockchain client the `--no-default-features` build option will need to be used.~~ No blockchain client is included in the `default` features, so if one is needed it must be specified with `--features`.  I also added a default esplora server url so the user doesn't need to specify one if selecting that client, which is how the electrum and compact_filters clients work.

### Notes to the reviewers

I changed the server option for both `electrum` and `esplora` to --server or -s since that now won't cause a conflict. I also simplified the CHANGELOG to focus on what a user would see as a change while using the bin.

I've also added a `build.rs` file to prevent more than one blockchain client feature from being enabled.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
