### PR TITLE
Use directly FromStr types in StructOpt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,10 +973,10 @@ pub enum KeySubCommand {
     Derive {
         /// Extended private key to derive from
         #[structopt(name = "XPRV", short = "x", long = "xprv")]
-        xprv: String,
+        xprv: ExtendedPrivKey,
         /// Path to use to derive extended public key from extended private key
         #[structopt(name = "PATH", short = "p", long = "path")]
-        path: String,
+        path: DerivationPath,
     },
 }
 
@@ -1021,14 +1021,12 @@ pub fn handle_key_subcommand(
             Ok(json!({ "xprv": xprv.to_string(), "fingerprint": fingerprint.to_string() }))
         }
         KeySubCommand::Derive { xprv, path } => {
-            let xprv = ExtendedPrivKey::from_str(xprv.as_str())?;
             if xprv.network != network {
                 return Err(Error::Key(InvalidNetwork));
             }
-            let deriv_path: DerivationPath = DerivationPath::from_str(path.as_str())?;
-            let derived_xprv = &xprv.derive_priv(&secp, &deriv_path)?;
+            let derived_xprv = &xprv.derive_priv(&secp, &path)?;
 
-            let origin: KeySource = (xprv.fingerprint(&secp), deriv_path);
+            let origin: KeySource = (xprv.fingerprint(&secp), path);
 
             let derived_xprv_desc_key: DescriptorKey<Segwitv0> =
                 derived_xprv.into_descriptor_key(Some(origin), DerivationPath::default())?;


### PR DESCRIPTION
With wrong values instead of getting:
[2021-09-21T13:25:13Z ERROR bdk_cli] Bip32(Base58(BadChecksum(1292914229, 1275556062)))

you get:
error: Invalid value for '--xprv <XPRV>': base58 encoding error: base58ck checksum 0x4c0770de does not match expected 0x4d104e35

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
