### PR TITLE
Small explora fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Update default feature to not include electrum
-- Upgrade to `bdk` v0.7.x
+- Upgrade to `bdk` v0.12.x
 - Add top level command "Compile" which compiles a miniscript policy to an output descriptor
 - Add `CompactFilterOpts` to `WalletOpts` to enable compact-filter blockchain configuration
 - Add `verbose` option to `WalletOpts` to display PSBTs and transaction details also in JSON format
 - Require at most one blockchain client feature be enabled at a time
+- Change default esplora server URL to https://blockstream.info/testnet/api/ to match default testnet network
 
 ## [0.2.0]
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ bdk-cli help # to verify it worked
 If no blockchain client feature is enabled online wallet commands `sync` and `broadcast` will be 
 disabled. To enable these commands a blockchain client features such as `electrum` or another 
 blockchain backend feature must be enabled. Below is an example of how run the `bdk-cli` bin with 
-the `esplora` blockchain client feature.
+the `esplora-ureq` blockchain client feature.
 
 ```shell
-RUST_LOG=debug cargo run --features esplora -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
+RUST_LOG=debug cargo run --features esplora-ureq -- wallet --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
 ```
 
 At most one blockchain feature can be enabled, available blockchain client features are:
-`electrum`, `esplora`, and `compact_filters`.
+`electrum`, `esplora-ureq` (blocking), `esplora-reqwest` (async), and `compact_filters`.
 
 ### From crates.io
 You can the install the binaries for the latest tag of `bdk-cli` with online wallet features 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,14 +183,14 @@ use bdk::{FeeRate, KeychainKind, Wallet};
 ///               },
 ///               #[cfg(feature = "esplora-ureq")]
 ///               esplora_opts: EsploraOpts {
-///                   server: "https://blockstream.info/api/".to_string(),
+///                   server: "https://blockstream.info/testnet/api/".to_string(),
 ///                   read_timeout: 5,
 ///                   write_timeout: 5,
 ///                   stop_gap: 10
 ///               },
 ///               #[cfg(feature = "esplora-reqwest")]
 ///               esplora_opts: EsploraOpts {
-///                   server: "https://blockstream.info/api/".to_string(),
+///                   server: "https://blockstream.info/testnet/api/".to_string(),
 ///                   conc: 4,
 ///                   stop_gap: 10
 ///               },
@@ -336,14 +336,14 @@ pub enum WalletSubCommand {
 ///               },
 ///               #[cfg(feature = "esplora-ureq")]
 ///               esplora_opts: EsploraOpts {
-///                   server: "https://blockstream.info/api/".to_string(),
+///                   server: "https://blockstream.info/testnet/api/".to_string(),
 ///                   read_timeout: 5,
 ///                   write_timeout: 5,
 ///                   stop_gap: 10
 ///               },
 ///               #[cfg(feature = "esplora-reqwest")]
 ///               esplora_opts: EsploraOpts {
-///                   server: "https://blockstream.info/api/".to_string(),
+///                   server: "https://blockstream.info/testnet/api/".to_string(),
 ///                   conc: 4,
 ///                   stop_gap: 10
 ///               },
@@ -488,7 +488,7 @@ pub struct EsploraOpts {
         name = "ESPLORA_URL",
         short = "s",
         long = "server",
-        default_value = "https://blockstream.info/api/"
+        default_value = "https://blockstream.info/testnet/api/"
     )]
     pub server: String,
 
@@ -518,7 +518,7 @@ pub struct EsploraOpts {
         name = "ESPLORA_URL",
         short = "s",
         long = "server",
-        default_value = "https://blockstream.info/api/"
+        default_value = "https://blockstream.info/testnet/api/"
     )]
     pub server: String,
 
@@ -1182,14 +1182,14 @@ mod test {
                     },
                     #[cfg(feature = "esplora-ureq")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         read_timeout: 5,
                         write_timeout: 5,
                         stop_gap: 10,
                     },
                     #[cfg(feature = "esplora-reqwest")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
                         stop_gap: 10,
                     },
@@ -1242,7 +1242,7 @@ mod test {
                     },
                     #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         concurrency: 4,
                     },
                     #[cfg(feature = "compact_filters")]
@@ -1287,25 +1287,12 @@ mod test {
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
-                    #[cfg(feature = "electrum")]
-                    electrum_opts: ElectrumOpts {
-                        timeout: None,
-                        server: "ssl://electrum.blockstream.info:60002".to_string(),
-                    },
-                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/api/".to_string(),
                         read_timeout: 10,
                         write_timeout: 10,
                         stop_gap: 20
                     },
-                    #[cfg(feature = "compact_filters")]
-                    compactfilter_opts: CompactFilterOpts{
-                        address: vec!["127.0.0.1:18444".to_string()],
-                        skip_blocks: 0,
-                        conn_count: 4,
-                    },
-                    #[cfg(any(feature="compact_filters", feature="electrum", feature="esplora"))]
                     proxy_opts: ProxyOpts{
                         proxy: None,
                         proxy_auth: None,
@@ -1340,24 +1327,11 @@ mod test {
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
-                    #[cfg(feature = "electrum")]
-                    electrum_opts: ElectrumOpts {
-                        timeout: None,
-                        server: "ssl://electrum.blockstream.info:60002".to_string(),
-                    },
-                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/api/".to_string(),
                         conc: 10,
                         stop_gap: 20
                     },
-                    #[cfg(feature = "compact_filters")]
-                    compactfilter_opts: CompactFilterOpts{
-                        address: vec!["127.0.0.1:18444".to_string()],
-                        skip_blocks: 0,
-                        conn_count: 4,
-                    },
-                    #[cfg(any(feature="compact_filters", feature="electrum", feature="esplora"))]
                     proxy_opts: ProxyOpts{
                         proxy: None,
                         proxy_auth: None,
@@ -1394,23 +1368,11 @@ mod test {
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
-                    #[cfg(feature = "electrum")]
-                    electrum_opts: ElectrumOpts {
-                        timeout: None,
-                        server: "ssl://electrum.blockstream.info:60002".to_string(),
-                    },
-                    #[cfg(feature = "esplora")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
-                        concurrency: 4,
-                    },
-                    #[cfg(feature = "compact_filters")]
                     compactfilter_opts: CompactFilterOpts{
                         address: vec!["127.0.0.1:18444".to_string(), "127.2.3.1:19695".to_string()],
                         conn_count: 4,
                         skip_blocks: 5,
                     },
-                    #[cfg(any(feature="compact_filters", feature="electrum"))]
                     proxy_opts: ProxyOpts{
                         proxy: Some("127.0.0.1:9005".to_string()),
                         proxy_auth: Some(("random_user".to_string(), "random_passwd".to_string())),
@@ -1449,14 +1411,14 @@ mod test {
                     },
                     #[cfg(feature = "esplora-ureq")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         read_timeout: 5,
                         write_timeout: 5,
                         stop_gap: 10,
                     },
                     #[cfg(feature = "esplora-reqwest")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
                         stop_gap: 10,
                     },
@@ -1524,14 +1486,14 @@ mod test {
                     },
                     #[cfg(feature = "esplora-ureq")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         read_timeout: 5,
                         write_timeout: 5,
                         stop_gap: 10,
                     },
                     #[cfg(feature = "esplora-reqwest")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
                         stop_gap: 10,
                     },
@@ -1591,14 +1553,14 @@ mod test {
                     },
                     #[cfg(feature = "esplora-ureq")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         read_timeout: 5,
                         write_timeout: 5,
                         stop_gap: 10,
                     },
                     #[cfg(feature = "esplora-reqwest")]
                     esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/api/".to_string(),
+                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
                         stop_gap: 10,
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1234,24 +1234,11 @@ mod test {
                     verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
-                    #[cfg(feature = "electrum")]
                     electrum_opts: ElectrumOpts {
                         timeout: Some(10),
                         server: "ssl://electrum.blockstream.info:50002".to_string(),
                         stop_gap: 20
                     },
-                    #[cfg(feature = "esplora")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/testnet/api/".to_string(),
-                        concurrency: 4,
-                    },
-                    #[cfg(feature = "compact_filters")]
-                    compactfilter_opts: CompactFilterOpts{
-                        address: vec!["127.0.0.1:18444".to_string()],
-                        conn_count: 4,
-                        skip_blocks: 0,
-                    },
-                    #[cfg(any(feature="compact_filters", feature="electrum"))]
                     proxy_opts: ProxyOpts{
                         proxy: Some("127.0.0.1:9150".to_string()),
                         proxy_auth: None,


### PR DESCRIPTION
### Description

* Fix default esplora server URL to `https://blockstream.info/testnet/api` to match default `bdk-cli` network which is also `testnet`. 
* Update README instructions and examples with features `esplora-ureq` and `esplora-reqest`.

### Notes to the reviewers

I think this is the simplest way to fix the esplora server URL to match the specified bitcoin network. If the user uses the option to change the bitcoin network then they should also expect to change the esplora (or other blockchain client) server url.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
