### PR TITLE
Replace `wallet bump_fee` command `--send_all` with new `--shrink` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Replace `wallet bump_fee` command `--send_all` with new `--shrink` option
+
 ## [0.3.0]
 
 - Add RPC backend support, after bdk v0.12.0 release


### PR DESCRIPTION
### Description

Replace `wallet bump_fee` command `--send_all` with new `--shrink ADDRESS` option to reduce the output amount for the  specified address to increase RBF transaction fee.

### Notes to the reviewers

This new option is primarily needed when bumping the fee of a `send_all` transaction or any other transaction that doesn't have a change output that can be reduced to bump the fee on the new RBF transaction.

Steps I used to test
1. create wallet with two utxos 
2. create and broadcast send_all tx with rbf enabled and 1 sat/vbyte fee back to testnet faucet
3. create and broadcast bump_fee rbf for above tx with 7 sat/vbyte fee and shrinking the testnet faucet address

https://mempool.space/testnet/tx/e35892843875e084f39c5285ee6f522764210351f78cd89305a49efbf4bfea48

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
