### PR TITLE
if no wallet name was provided, use one derived from the descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace `wallet bump_fee` command `--send_all` with new `--shrink` option
 - Add 'reserve' feature to enable proof of reserve
+- If no wallet name is provided, derive one from the descriptor instead of using "main"
 
 ## [0.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ec4da3dbaa41bb6d6cffe40b113ea8651566da7f96beebe9c0e87fc92b9094"
+checksum = "90456af1a5ceb48721ce092d97bd37d2d932c2877a352f52c934d8a564f62e49"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bdk-reserves"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af45ab67ba3a9e2bf44c0567a89b60cdcf3bcc21ae52938d98c8d2eaa1078a08"
+checksum = "6be281faf67beffdfbdb2b049dba1f97d58c7f46ff9d9586811c813d7abf9485"
 dependencies = [
  "base64 0.11.0",
  "bdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90456af1a5ceb48721ce092d97bd37d2d932c2877a352f52c934d8a564f62e49"
+checksum = "636aafcdd74940530a9ea644e3def456b493ec42fdd0bd2bb1ae3338b2032849"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -96,7 +96,7 @@ dependencies = [
  "lazy_static",
  "log",
  "miniscript",
- "rand 0.7.3",
+ "rand",
  "reqwest",
  "rocksdb",
  "serde",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bdk-reserves"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be281faf67beffdfbdb2b049dba1f97d58c7f46ff9d9586811c813d7abf9485"
+checksum = "85397162a769b6162033c4ed8edc6285d347006eac5299dd186dee7bd77e8c88"
 dependencies = [
  "base64 0.11.0",
  "bdk",
@@ -340,22 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "crc32fast"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,21 +468,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -759,19 +728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,24 +929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,39 +975,6 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1119,12 +1024,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e"
 
 [[package]]
 name = "ppv-lite86"
@@ -1198,21 +1097,9 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha 0.2.2",
+ "rand_chacha",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1223,16 +1110,6 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1251,30 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1314,15 +1173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,20 +1186,17 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-socks",
  "url",
  "wasm-bindgen",
@@ -1446,16 +1293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,29 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1675,20 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
-dependencies = [
- "cfg-if",
- "libc",
- "rand 0.8.4",
- "redox_syscall",
- "remove_dir_all",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,16 +1539,6 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -1884,12 +1674,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "0.15", default-features = false, features = ["all-keys"]}
+bdk = { version = "0.16", default-features = false, features = ["all-keys"]}
 bdk-macros = "0.6"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
@@ -26,7 +26,7 @@ dirs-next = { version = "2.0", optional = true }
 env_logger = { version = "0.7", optional = true }
 clap = { version = "2.33", optional = true }
 regex = { version = "1", optional = true }
-bdk-reserves = { version = "0.15", optional = true}
+bdk-reserves = { version = "0.16", optional = true}
 
 [features]
 default = ["cli", "repl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-bdk = { version = "0.14.0", default-features = false, features = ["all-keys"]}
+bdk = { version = "0.15", default-features = false, features = ["all-keys"]}
 bdk-macros = "0.6"
 structopt = "^0.3"
 serde_json = { version = "^1.0" }
@@ -26,7 +26,7 @@ dirs-next = { version = "2.0", optional = true }
 env_logger = { version = "0.7", optional = true }
 clap = { version = "2.33", optional = true }
 regex = { version = "1", optional = true }
-bdk-reserves = { version = "0.14.2", optional = true}
+bdk-reserves = { version = "0.15", optional = true}
 
 [features]
 default = ["cli", "repl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ use bdk_reserves::reserves::ProofOfReserves;
 ///             network: Network::Testnet,
 ///             subcommand: CliSubCommand::Wallet {
 ///                 wallet_opts: WalletOpts {
-///                     wallet: "main".to_string(),
+///                     wallet: None,
 ///                     verbose: false,
 ///                     descriptor: "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)".to_string(),
 ///                     change_descriptor: None,
@@ -219,18 +219,12 @@ use bdk_reserves::reserves::ProofOfReserves;
 ///                   server: "ssl://electrum.blockstream.info:60002".to_string(),
 ///                   stop_gap: 10
 ///               },
-///               #[cfg(feature = "esplora-ureq")]
+///               #[cfg(feature = "esplora")]
 ///               esplora_opts: EsploraOpts {
 ///                   server: "https://blockstream.info/testnet/api/".to_string(),
-///                   read_timeout: 5,
-///                   write_timeout: 5,
-///                   stop_gap: 10
-///               },
-///               #[cfg(feature = "esplora-reqwest")]
-///               esplora_opts: EsploraOpts {
-///                   server: "https://blockstream.info/testnet/api/".to_string(),
-///                   conc: 4,
-///                   stop_gap: 10
+///                   timeout: 5,
+///                   stop_gap: 10,
+///                   conc: 4
 ///               },
 ///                 #[cfg(feature = "rpc")]
 ///                 rpc_opts: RpcOpts{
@@ -395,7 +389,7 @@ pub enum WalletSubCommand {
 /// let wallet_opts = WalletOpts::from_iter(&cli_args);
 ///
 /// let expected_wallet_opts = WalletOpts {
-///               wallet: "main".to_string(),
+///               wallet: None,
 ///                     verbose: false,
 ///               descriptor: "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)".to_string(),
 ///               change_descriptor: None,
@@ -405,18 +399,12 @@ pub enum WalletSubCommand {
 ///                   server: "ssl://electrum.blockstream.info:60002".to_string(),
 ///                   stop_gap: 10
 ///               },
-///               #[cfg(feature = "esplora-ureq")]
+///               #[cfg(feature = "esplora")]
 ///               esplora_opts: EsploraOpts {
 ///                   server: "https://blockstream.info/testnet/api/".to_string(),
-///                   read_timeout: 5,
-///                   write_timeout: 5,
-///                   stop_gap: 10
-///               },
-///               #[cfg(feature = "esplora-reqwest")]
-///               esplora_opts: EsploraOpts {
-///                   server: "https://blockstream.info/testnet/api/".to_string(),
-///                   conc: 4,
-///                   stop_gap: 10
+///                   timeout: 5,
+///                   stop_gap: 10,
+///                   conc: 4
 ///               },
 ///                #[cfg(feature = "compact_filters")]
 ///                compactfilter_opts: CompactFilterOpts{
@@ -444,13 +432,8 @@ pub enum WalletSubCommand {
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 pub struct WalletOpts {
     /// Selects the wallet to use
-    #[structopt(
-        name = "WALLET_NAME",
-        short = "w",
-        long = "wallet",
-        default_value = "main"
-    )]
-    pub wallet: String,
+    #[structopt(name = "WALLET_NAME", short = "w", long = "wallet")]
+    pub wallet: Option<String>,
     /// Adds verbosity, returns PSBT in JSON format alongside serialized, displays expanded objects
     #[structopt(name = "VERBOSE", short = "v", long = "verbose")]
     pub verbose: bool,
@@ -588,7 +571,7 @@ pub struct ElectrumOpts {
 /// Esplora options
 ///
 /// Esplora blockchain client information used by [`OnlineWalletSubCommand`]s.
-#[cfg(feature = "esplora-ureq")]
+#[cfg(feature = "esplora")]
 #[derive(Debug, StructOpt, Clone, PartialEq)]
 pub struct EsploraOpts {
     /// Use the esplora server if given as parameter
@@ -600,13 +583,9 @@ pub struct EsploraOpts {
     )]
     pub server: String,
 
-    /// Socket read timeout
-    #[structopt(name = "READ_TIMEOUT", long = "read_timeout", default_value = "5")]
-    pub read_timeout: u64,
-
-    /// Socket write timeout
-    #[structopt(name = "WRITE_TIMEOUT", long = "write_timeout", default_value = "5")]
-    pub write_timeout: u64,
+    /// Socket timeout
+    #[structopt(name = "TIMEOUT", long = "timeout", default_value = "5")]
+    pub timeout: u64,
 
     /// Stop searching addresses for transactions after finding an unused gap of this length.
     #[structopt(
@@ -616,32 +595,10 @@ pub struct EsploraOpts {
         default_value = "10"
     )]
     pub stop_gap: usize,
-}
-
-#[cfg(feature = "esplora-reqwest")]
-#[derive(Debug, StructOpt, Clone, PartialEq)]
-pub struct EsploraOpts {
-    /// Use the esplora server if given as parameter
-    #[structopt(
-        name = "ESPLORA_URL",
-        short = "s",
-        long = "server",
-        default_value = "https://blockstream.info/testnet/api/"
-    )]
-    pub server: String,
 
     /// Number of parallel requests sent to the esplora service (default: 4)
     #[structopt(name = "CONCURRENCY", long = "conc", default_value = "4")]
     pub conc: u8,
-
-    /// Stop searching addresses for transactions after finding an unused gap of this length.
-    #[structopt(
-        name = "STOP_GAP",
-        long = "stop_gap",
-        short = "g",
-        default_value = "10"
-    )]
-    pub stop_gap: usize,
 }
 
 // This is a workaround for `structopt` issue #333, #391, #418; see https://github.com/TeXitoi/structopt/issues/333#issuecomment-712265332
@@ -1467,7 +1424,7 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
@@ -1477,18 +1434,12 @@ mod test {
                         server: "ssl://electrum.blockstream.info:60002".to_string(),
                         stop_gap: 10,
                     },
-                    #[cfg(feature = "esplora-ureq")]
+                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
-                    },
-                    #[cfg(feature = "esplora-reqwest")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
-                        stop_gap: 10,
                     },
                     #[cfg(feature = "compact_filters")]
                     compactfilter_opts: CompactFilterOpts{
@@ -1533,7 +1484,7 @@ mod test {
             network: Network::Testnet,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
@@ -1562,8 +1513,7 @@ mod test {
                             "--descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)",
                             "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
                             "--server", "https://blockstream.info/api/",
-                            "--read_timeout", "10",
-                            "--write_timeout", "10",
+                            "--timeout", "10",
                             "--stop_gap", "20",
                             "get_new_address"];
 
@@ -1573,15 +1523,15 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/api/".to_string(),
-                        read_timeout: 10,
-                        write_timeout: 10,
-                        stop_gap: 20
+                        timeout: 10,
+                        stop_gap: 20,
+                        conc: 4,
                     },
                     proxy_opts: ProxyOpts{
                         proxy: None,
@@ -1613,14 +1563,15 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/api/".to_string(),
                         conc: 10,
-                        stop_gap: 20
+                        stop_gap: 20,
+                        timeout: 5,
                     },
                     proxy_opts: ProxyOpts{
                         proxy: None,
@@ -1652,7 +1603,7 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
@@ -1688,7 +1639,7 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
@@ -1728,7 +1679,7 @@ mod test {
             network: Network::Testnet,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: None,
@@ -1738,18 +1689,12 @@ mod test {
                         server: "ssl://electrum.blockstream.info:60002".to_string(),
                         stop_gap: 10,
                     },
-                    #[cfg(feature = "esplora-ureq")]
+                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
-                    },
-                    #[cfg(feature = "esplora-reqwest")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
-                        stop_gap: 10,
                     },
                     #[cfg(feature = "compact_filters")]
                     compactfilter_opts: CompactFilterOpts{
@@ -1809,7 +1754,7 @@ mod test {
             network: Network::Testnet,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
@@ -1819,18 +1764,12 @@ mod test {
                         server: "ssl://electrum.blockstream.info:60002".to_string(),
                         stop_gap: 10,
                     },
-                    #[cfg(feature = "esplora-ureq")]
+                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
-                    },
-                    #[cfg(feature = "esplora-reqwest")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
-                        stop_gap: 10,
                     },
                     #[cfg(feature = "compact_filters")]
                     compactfilter_opts: CompactFilterOpts{
@@ -1883,7 +1822,7 @@ mod test {
             network: Network::Testnet,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
@@ -1893,18 +1832,12 @@ mod test {
                         server: "ssl://electrum.blockstream.info:60002".to_string(),
                         stop_gap: 10,
                     },
-                    #[cfg(feature = "esplora-ureq")]
+                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
-                    },
-                    #[cfg(feature = "esplora-reqwest")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
-                        stop_gap: 10,
                     },
                     #[cfg(feature = "compact_filters")]
                     compactfilter_opts: CompactFilterOpts{
@@ -1958,7 +1891,7 @@ mod test {
             network: Network::Testnet,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: None,
@@ -1968,18 +1901,12 @@ mod test {
                         server: "ssl://electrum.blockstream.info:60002".to_string(),
                         stop_gap: 10,
                     },
-                    #[cfg(feature = "esplora-ureq")]
+                    #[cfg(feature = "esplora")]
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
-                    },
-                    #[cfg(feature = "esplora-reqwest")]
-                    esplora_opts: EsploraOpts {
-                        server: "https://blockstream.info/testnet/api/".to_string(),
                         conc: 4,
-                        stop_gap: 10,
                     },
                     #[cfg(feature = "compact_filters")]
                     compactfilter_opts: CompactFilterOpts{
@@ -2140,7 +2067,7 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)"
                         .to_string(),
@@ -2190,16 +2117,16 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)"
                         .to_string(),
                     change_descriptor: None,
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
+                        conc: 4,
                     },
                     proxy_opts: ProxyOpts {
                         proxy: None,
@@ -2245,16 +2172,16 @@ mod test {
             network: Network::Bitcoin,
             subcommand: CliSubCommand::Wallet {
                 wallet_opts: WalletOpts {
-                    wallet: "main".to_string(),
+                    wallet: None,
                     verbose: false,
                     descriptor: "wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)"
                         .to_string(),
                     change_descriptor: None,
                     esplora_opts: EsploraOpts {
                         server: "https://blockstream.info/testnet/api/".to_string(),
-                        read_timeout: 5,
-                        write_timeout: 5,
+                        timeout: 5,
                         stop_gap: 10,
+                        conc: 4,
                     },
                     proxy_opts: ProxyOpts {
                         proxy: None,


### PR DESCRIPTION
### Description

if no wallet name was provided, use one derived from the descriptor

### Notes to the reviewers

Is there a better place to use wallet_name_from_descriptor so that the generated name shows up in the unit tests instead of the placeholder?

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
