### PR TITLE
Update codecov to grcov from Tarpauline

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -3,25 +3,53 @@ on: [push]
 name: Code Coverage
 
 jobs:
-  tarpaulin-codecov:
-    name: Tarpaulin to codecov.io
+
+  codecov:
+    name: Code Coverage
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: '0'
+      RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+      RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set default toolchain
-        run: rustup default nightly
+      - name: Install rustup
+        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Set profile
         run: rustup set profile minimal
+      - name: Update toolchain
+        run: rustup update
+      - name: Override the default toolchain
+        run: rustup override set nightly
 
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Tarpaulin
-        run: cargo tarpaulin --features default --run-types Tests,Doctests --out Xml
 
-      - name: Publish to codecov.io
-        uses: codecov/codecov-action@v2.1.0
+      - name: Test Compiler
+        run: cargo test --features compiler
+
+      - name: Test Electrum
+        run: cargo test --features electrum
+
+      - name: Test Esplora-Ureq
+        run: cargo test --features esplora-ureq
+
+      - name: Test Esplora-reqwest
+        run: cargo test --features esplora-reqwest
+
+      - name: Test Compact Filters
+        run: cargo test --features compact_filters
+
+      - name: Test RPC
+        run: cargo test --features rpc
+
+      - id: coverage
+        name: Generate coverage
+        uses: actions-rs/grcov@v0.1.5
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
         with:
-          fail_ci_if_error: true
-          file: ./cobertura.xml
+          file: ${{ steps.coverage.outputs.report }}
+          directory: ./coverage/reports/


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

To match with existing codecov of BDK, Tarpaulin based codecov in bdk-cli is changed to grcov.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
