### PR TITLE
Add cookie authentication option for rpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `wallet bump_fee` command `--send_all` with new `--shrink` option
 - Add 'reserve' feature to enable proof of reserve
 - If no wallet name is provided, derive one from the descriptor instead of using "main"
+- Add optional cookie authentication for rpc backend
 
 ## [0.3.0]
 

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -191,9 +191,15 @@ where
 
     #[cfg(feature = "rpc")]
     let config: AnyBlockchainConfig = {
-        let auth = Auth::UserPass {
-            username: wallet_opts.rpc_opts.auth.0.clone(),
-            password: wallet_opts.rpc_opts.auth.1.clone(),
+        let auth = if let Some(cookie) = &wallet_opts.rpc_opts.cookie {
+            Auth::Cookie {
+                file: cookie.into(),
+            }
+        } else {
+            Auth::UserPass {
+                username: wallet_opts.rpc_opts.basic_auth.0.clone(),
+                password: wallet_opts.rpc_opts.basic_auth.1.clone(),
+            }
         };
 
         // Use deterministic wallet name derived from descriptor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,8 +229,9 @@ use bdk_reserves::reserves::ProofOfReserves;
 ///                 #[cfg(feature = "rpc")]
 ///                 rpc_opts: RpcOpts{
 ///                    address: "127.0.0.1:18443".to_string(),
-///                    auth: ("user".to_string(), "password".to_string()),
+///                    basic_auth: ("user".to_string(), "password".to_string()),
 ///                    skip_blocks: None,
+///                    cookie: None,
 ///                },
 ///                #[cfg(feature = "compact_filters")]
 ///                compactfilter_opts: CompactFilterOpts{
@@ -542,15 +543,19 @@ pub struct RpcOpts {
     )]
     pub address: String,
 
-    /// Sets the rpc authentication username:password
+    /// Sets the rpc basic authentication
     #[structopt(
         name = "USER:PASSWD",
         short = "a",
-        long = "auth",
+        long = "basic-auth",
         parse(try_from_str = parse_proxy_auth),
         default_value = "user:password",
     )]
-    pub auth: (String, String),
+    pub basic_auth: (String, String),
+
+    /// Sets an optional cookie authentication
+    #[structopt(name = "COOKIE", long = "cookie")]
+    pub cookie: Option<String>,
 
     /// Optionally skip initial `skip_blocks` blocks
     #[structopt(name = "SKIP_BLOCKS", short = "s", long = "skip-blocks")]
@@ -1479,7 +1484,8 @@ mod test {
                     #[cfg(feature = "rpc")]
                     rpc_opts: RpcOpts {
                         address: "127.0.0.1:18443".to_string(),
-                        auth: ("user".to_string(), "password".to_string()),
+                        basic_auth: ("user".to_string(), "password".to_string()),
+                        cookie: None,
                         skip_blocks: None,
                     },
                 },
@@ -1616,7 +1622,8 @@ mod test {
                             "--descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)",
                             "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
                             "--node", "125.67.89.101:56678",
-                            "--auth", "user:password",
+                            "--basic-auth", "user:password",
+                            "--cookie", "/home/user/.bitcoin/regtest/.cookie",
                             "--skip-blocks", "5",
                             "get_new_address"];
 
@@ -1632,7 +1639,8 @@ mod test {
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     rpc_opts: RpcOpts {
                         address: "125.67.89.101:56678".to_string(),
-                        auth: ("user".to_string(), "password".to_string()),
+                        basic_auth: ("user".to_string(), "password".to_string()),
+                        cookie: Some("/home/user/.bitcoin/regtest/.cookie".to_string()),
                         skip_blocks: Some(5),
                     },
                 },
@@ -1734,7 +1742,8 @@ mod test {
                     #[cfg(feature = "rpc")]
                     rpc_opts: RpcOpts {
                         address: "127.0.0.1:18443".to_string(),
-                        auth: ("user".to_string(), "password".to_string()),
+                        basic_auth: ("user".to_string(), "password".to_string()),
+                        cookie: None,
                         skip_blocks: None,
                     },
                 },
@@ -1809,7 +1818,8 @@ mod test {
                     #[cfg(feature = "rpc")]
                     rpc_opts: RpcOpts {
                         address: "127.0.0.1:18443".to_string(),
-                        auth: ("user".to_string(), "password".to_string()),
+                        basic_auth: ("user".to_string(), "password".to_string()),
+                        cookie: None,
                         skip_blocks: None,
                     },
                 },
@@ -1871,7 +1881,8 @@ mod test {
                     #[cfg(feature = "rpc")]
                     rpc_opts: RpcOpts {
                         address: "127.0.0.1:18443".to_string(),
-                        auth: ("user".to_string(), "password".to_string()),
+                        basic_auth: ("user".to_string(), "password".to_string()),
+                        cookie: None,
                         skip_blocks: None,
                     },
                     #[cfg(any(feature="compact_filters", feature="electrum", feature="esplora"))]
@@ -1946,7 +1957,8 @@ mod test {
                     #[cfg(feature = "rpc")]
                     rpc_opts: RpcOpts {
                         address: "127.0.0.1:18443".to_string(),
-                        auth: ("user".to_string(), "password".to_string()),
+                        basic_auth: ("user".to_string(), "password".to_string()),
+                        cookie: None,
                         skip_blocks: None,
                     },
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,8 +426,9 @@ let expected_wallet_opts = WalletOpts {
                #[cfg(feature = "rpc")]
                rpc_opts: RpcOpts{
                     address: "127.0.0.1:18443".to_string(),
-                    auth: ("user".to_string(), "password".to_string()),
+                    basic_auth: ("user".to_string(), "password".to_string()),
                     skip_blocks: None,
+                    cookie: None,
                },
                #[cfg(any(feature="compact_filters", feature="electrum", feature="esplora"))]
                     proxy_opts: ProxyOpts{


### PR DESCRIPTION
### Description

Fixes https://github.com/bitcoindevkit/bdk-cli/issues/67

This PR adds an optional `cookie` arg to pass on cookie file if user needs to use that instead of basic user:password based authentication.

bitcoin core will only generate a `.cookie` file if rpc username passwords are not set in `bitcoin.conf`. Thus cookie file doesn't have a default. User should only provide it if they know a cookie file exists, or else "File not found" error is returned.     

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`