### PR TITLE
Add key-value-db and sqlite-db features, separate wallet directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `regtest` the default network.
 - Add experimental `regtest-*` features to automatically deploy local regtest nodes
 (bitcoind, and electrs) while running cli commands.
+- Put cached wallet data in separate directories: ~/.bdk-bitcoin/<wallet_name>
+- Add distinct `key-value-db` and `sqlite-db` features, keep default as `key-value-db`
 
 ## [0.4.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.6",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +107,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00fa2bcfe9debe57f32285ef56cb218b2e0dbf91e476ad22f61a745d4c032a18"
 dependencies = [
+ "ahash",
  "async-trait",
  "bdk-macros",
  "bip39",
@@ -112,6 +124,7 @@ dependencies = [
  "rand",
  "reqwest",
  "rocksdb",
+ "rusqlite",
  "serde",
  "serde_json",
  "sled",
@@ -569,6 +582,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +815,18 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -995,6 +1032,16 @@ dependencies = [
  "cc",
  "glob",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1440,6 +1487,21 @@ checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec 1.8.0",
 ]
 
 [[package]]
@@ -2076,6 +2138,12 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,11 @@ bdk-reserves = { version = "0.17", optional = true}
 electrsd = { version= "0.12", features = ["trigger", "bitcoind_22_0"], optional = true}
 
 [features]
-default = ["cli", "repl"]
-cli = ["bdk/key-value-db", "clap", "dirs-next", "env_logger"]
+default = ["cli", "repl", "key-value-db"]
+cli = ["clap", "dirs-next", "env_logger"]
 repl = ["regex", "rustyline", "fd-lock"]
+key-value-db = ["bdk/key-value-db"]
+sqlite-db = ["bdk/sqlite"]
 electrum = ["bdk/electrum"]
 esplora = []
 esplora-ureq = ["esplora", "bdk/use-esplora-ureq"]

--- a/build.rs
+++ b/build.rs
@@ -16,4 +16,21 @@ fn main() {
     if blockchain_features.len() > 1 {
         panic!("At most one blockchain client feature can be enabled but these features were enabled: {:?}", blockchain_features)
     }
+
+    let key_value_db =
+        env::var_os("CARGO_FEATURE_KEY_VALUE_DB").map(|_| "key-value-db".to_string());
+    let sqlite_db = env::var_os("CARGO_FEATURE_SQLITE_DB").map(|_| "sqlite-db".to_string());
+
+    let database_features: Vec<String> = vec![key_value_db, sqlite_db]
+        .iter()
+        .map(|f| f.to_owned())
+        .flatten()
+        .collect();
+
+    if database_features.len() > 1 {
+        panic!(
+            "At most one database feature can be enabled but these features were enabled: {:?}",
+            database_features
+        )
+    }
 }

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -91,7 +91,7 @@ enum ReplSubCommand {
 }
 
 /// prepare bdk_cli home and wallet directory
-fn prepare_home_wallet_dir(wallet_name: &String) -> Result<PathBuf, Error> {
+fn prepare_home_wallet_dir(wallet_name: &str) -> Result<PathBuf, Error> {
     let mut dir = PathBuf::new();
     dir.push(
         &dirs_next::home_dir().ok_or_else(|| Error::Generic("home dir not found".to_string()))?,
@@ -114,7 +114,7 @@ fn prepare_home_wallet_dir(wallet_name: &String) -> Result<PathBuf, Error> {
 }
 
 /// Prepare wallet database directory
-fn prepare_wallet_db_dir(wallet_name: &String) -> Result<PathBuf, Error> {
+fn prepare_wallet_db_dir(wallet_name: &str) -> Result<PathBuf, Error> {
     let mut db_dir = prepare_home_wallet_dir(wallet_name)?;
 
     #[cfg(feature = "key-value-db")]
@@ -134,7 +134,7 @@ fn prepare_wallet_db_dir(wallet_name: &String) -> Result<PathBuf, Error> {
 
 /// Prepare blockchain data directory (for compact filters)
 #[cfg(feature = "compact_filters")]
-fn prepare_bc_dir(wallet_name: &String) -> Result<PathBuf, Error> {
+fn prepare_bc_dir(wallet_name: &str) -> Result<PathBuf, Error> {
     let mut bc_dir = prepare_home_wallet_dir(wallet_name)?;
 
     bc_dir.push("compact_filters");

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -43,9 +43,11 @@ use bdk::blockchain::{AnyBlockchain, AnyBlockchainConfig, ConfigurableBlockchain
 #[cfg(feature = "rpc")]
 use bdk::blockchain::rpc::{Auth, RpcConfig};
 
-use bdk::database::BatchDatabase;
-use bdk::sled;
-use bdk::sled::Tree;
+#[cfg(feature = "key-value-db")]
+use bdk::database::any::SledDbConfiguration;
+#[cfg(feature = "sqlite-db")]
+use bdk::database::any::SqliteDbConfiguration;
+use bdk::database::{AnyDatabase, AnyDatabaseConfig, BatchDatabase, ConfigurableDatabase};
 use bdk::wallet::wallet_name_from_descriptor;
 use bdk::Wallet;
 use bdk::{bitcoin, Error};
@@ -88,7 +90,8 @@ enum ReplSubCommand {
     Exit,
 }
 
-fn prepare_home_dir() -> Result<PathBuf, Error> {
+/// prepare bdk_cli home and wallet directory
+fn prepare_home_wallet_dir(wallet_name: &String) -> Result<PathBuf, Error> {
     let mut dir = PathBuf::new();
     dir.push(
         &dirs_next::home_dir().ok_or_else(|| Error::Generic("home dir not found".to_string()))?,
@@ -100,25 +103,75 @@ fn prepare_home_dir() -> Result<PathBuf, Error> {
         fs::create_dir(&dir).map_err(|e| Error::Generic(e.to_string()))?;
     }
 
-    #[cfg(not(feature = "compact_filters"))]
-    dir.push("database.sled");
+    dir.push(wallet_name);
 
-    #[cfg(feature = "compact_filters")]
-    dir.push("compact_filters");
+    if !dir.exists() {
+        info!("Creating wallet directory {}", dir.as_path().display());
+        fs::create_dir(&dir).map_err(|e| Error::Generic(e.to_string()))?;
+    }
+
     Ok(dir)
 }
 
-fn open_database(wallet_opts: &WalletOpts) -> Result<Tree, Error> {
-    let mut database_path = prepare_home_dir()?;
-    let wallet_name = wallet_opts
-        .wallet
-        .as_deref()
-        .expect("We should always have a wallet name at this point");
-    database_path.push(wallet_name);
-    let database = sled::open(database_path)?;
-    let tree = database.open_tree(&wallet_name)?;
+/// Prepare wallet database directory
+fn prepare_wallet_db_dir(wallet_name: &String) -> Result<PathBuf, Error> {
+    let mut db_dir = prepare_home_wallet_dir(wallet_name)?;
+
+    #[cfg(feature = "key-value-db")]
+    db_dir.push("wallet.sled");
+
+    #[cfg(feature = "sqlite-db")]
+    db_dir.push("wallet.sqlite");
+
+    #[cfg(not(feature = "sqlite-db"))]
+    if !db_dir.exists() {
+        info!("Creating database directory {}", db_dir.as_path().display());
+        fs::create_dir(&db_dir).map_err(|e| Error::Generic(e.to_string()))?;
+    }
+
+    Ok(db_dir)
+}
+
+/// Prepare blockchain data directory (for compact filters)
+#[cfg(feature = "compact_filters")]
+fn prepare_bc_dir(wallet_name: &String) -> Result<PathBuf, Error> {
+    let mut bc_dir = prepare_home_wallet_dir(wallet_name)?;
+
+    bc_dir.push("compact_filters");
+
+    if !bc_dir.exists() {
+        info!(
+            "Creating blockchain directory {}",
+            bc_dir.as_path().display()
+        );
+        fs::create_dir(&bc_dir).map_err(|e| Error::Generic(e.to_string()))?;
+    }
+
+    Ok(bc_dir)
+}
+
+fn open_database(wallet_opts: &WalletOpts) -> Result<AnyDatabase, Error> {
+    let wallet_name = wallet_opts.wallet.as_ref().expect("wallet name");
+    let database_path = prepare_wallet_db_dir(wallet_name)?;
+
+    #[cfg(feature = "key-value-db")]
+    let config = AnyDatabaseConfig::Sled(SledDbConfiguration {
+        path: database_path
+            .into_os_string()
+            .into_string()
+            .expect("path string"),
+        tree_name: wallet_name.to_string(),
+    });
+    #[cfg(feature = "sqlite-db")]
+    let config = AnyDatabaseConfig::Sqlite(SqliteDbConfiguration {
+        path: database_path
+            .into_os_string()
+            .into_string()
+            .expect("path string"),
+    });
+    let database = AnyDatabase::from_config(&config)?;
     debug!("database opened successfully");
-    Ok(tree)
+    Ok(database)
 }
 
 #[allow(dead_code)]
@@ -180,10 +233,11 @@ fn new_blockchain(
             }
         }
 
+        let wallet_name = wallet_opts.wallet.as_ref().expect("wallet name");
         AnyBlockchainConfig::CompactFilters(CompactFiltersBlockchainConfig {
             peers,
             network: _network,
-            storage_dir: prepare_home_dir()?
+            storage_dir: prepare_bc_dir(wallet_name)?
                 .into_os_string()
                 .into_string()
                 .map_err(|_| Error::Generic("Internal OS_String conversion error".to_string()))?,


### PR DESCRIPTION
### Description

- Add distinct `key-value-db` and `sqlite-db` features, keep default as `key-value-db`

- Put cached wallet data in separate directories: `~/.bdk-bitcoin/<wallet_name>`
- Put compact filter data in `<wallet_name>/compact_filters`
- Depending on the db used put cached wallet data in: `<wallet_name>/wallet.sled/` or `<wallet_name>/wallet.sqlite`

### Notes to the reviewers

This change will help test BDK with different databases, in particular for manually testing DB migrations such as in https://github.com/bitcoindevkit/bdk/pull/502.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
