### PR TITLE
[bug fix] Add `maybe_descriptor_wallet_name()` in repl mode

### DIFF
--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -374,8 +374,13 @@ fn handle_command(cli_opts: CliOpts, network: Network) -> Result<String, Error> 
                                     .as_str())
                             })
                             .collect::<Result<Vec<_>, Error>>()?;
-                        let repl_subcommand = ReplSubCommand::from_iter_safe(split_line)
-                            .map_err(|e| Error::Generic(e.to_string()))?;
+                        let repl_subcommand = ReplSubCommand::from_iter_safe(split_line);
+                        if let Err(err) = repl_subcommand {
+                            println!("{}", err.to_string());
+                            continue;
+                        }
+                        // if error will be printed above
+                        let repl_subcommand = repl_subcommand.unwrap();
                         debug!("repl_subcommand = {:?}", repl_subcommand);
 
                         let result = match repl_subcommand {

--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -328,6 +328,7 @@ fn handle_command(cli_opts: CliOpts, network: Network) -> Result<String, Error> 
         }
         #[cfg(feature = "repl")]
         CliSubCommand::Repl { wallet_opts } => {
+            let wallet_opts = maybe_descriptor_wallet_name(wallet_opts, network)?;
             let database = open_database(&wallet_opts)?;
 
             #[cfg(any(


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Because we didn't had `maybe_descriptor_wallet_name()` in repl, the following command would fail
```
$ ./target/debug/bdk-cli repl -d "wpkh([b8b575c2/84'/1'/0'/0]tprv8icWtRzy9CWgFxpGMLSdAeE4wWyz39XGc6SwykeTo13tYm14JkVVQAf7jz8WDDarCgNJrG3aEPJEqchDWeJdiaWpS3FwbLB9SzsN57V7qxB/*)"
thread 'main' panicked at 'We should always have a wallet name at this point', src/bdk_cli.rs:116:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```  

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
