### PR TITLE
Disable regex tests when repl feature not enabled

### DIFF
--- a/src/bdk_cli.rs
+++ b/src/bdk_cli.rs
@@ -560,9 +560,12 @@ fn handle_command(cli_opts: CliOpts, network: Network, _backend: Backend) -> Res
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "repl")]
     use crate::REPL_LINE_SPLIT_REGEX;
+    #[cfg(feature = "repl")]
     use regex::Regex;
 
+    #[cfg(feature = "repl")]
     #[test]
     fn test_regex_double_quotes() {
         let split_regex = Regex::new(REPL_LINE_SPLIT_REGEX).unwrap();
@@ -589,6 +592,7 @@ mod test {
         );
     }
 
+    #[cfg(feature = "repl")]
     #[test]
     fn test_regex_single_quotes() {
         let split_regex = Regex::new(REPL_LINE_SPLIT_REGEX).unwrap();


### PR DESCRIPTION
### Description

I noticed that when I disable default features and don't enable the `repl` feature that the regex tests fail because they need the regex dependency that the `repl` feature brings in. This PR is to simply disable the regex related test code if the `repl` feature isn't enabled.

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
