### PR TITLE
Remove some of the reserves and regtest features

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -22,15 +22,10 @@ jobs:
           - rpc
           - reserves
           - reserves,electrum
-          - reserves,esplora-ureq
-          - reserves,compact_filters
-          - reserves,rpc
           - electrum,verify
           # regtest-* features are experimental and not fully usable
           - regtest-bitcoin
           - regtest-electrum
-          - regtest-esplora-ureq
-          - regtest-esplora-reqwest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Currently the way `ExternalReserves` functionality is written, it can only be used with `electrum` feature. The tests should fail if the implementation behavior is enforced.. Disabling the tests in CI.

Also removing the `regtest-esplora` features from the tests, because they won't work when #92 lands. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing