### PR TITLE
Add add_data enables op_return for bdk-cli

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -396,6 +396,22 @@ pub enum OfflineWalletSubCommand {
         /// Selects which policy should be used to satisfy the internal descriptor.
         #[structopt(name = "INT_POLICY", long = "internal_policy")]
         internal_policy: Option<String>,
+        /// Optionally create an OP_RETURN output containing given String in utf8 encoding (max 80 bytes)
+        #[structopt(
+            name = "ADD_STRING",
+            long = "add_string",
+            short = "s",
+            conflicts_with = "ADD_DATA"
+        )]
+        add_string: Option<String>,
+        /// Optionally create an OP_RETURN output containing given base64 encoded String. (max 80 bytes)
+        #[structopt(
+            name = "ADD_DATA",
+            long = "add_data",
+            short = "o",
+            conflicts_with = "ADD_STRING"
+        )]
+        add_data: Option<String>, //base 64 econding
     },
     /// Bumps the fees of an RBF transaction.
     BumpFee {
@@ -945,7 +961,9 @@ mod test {
                             "--change_descriptor", "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
                             "create_tx", "--to", "n2Z3YNXtceeJhFkTknVaNjT1mnCGWesykJ:123456","mjDZ34icH4V2k9GmC8niCrhzVuR3z8Mgkf:78910",
                             "--utxos","87345e46bfd702d24d54890cc094d08a005f773b27c8f965dfe0eb1e23eef88e:1",
-                            "--utxos","87345e46bfd702d24d54890cc094d08a005f773b27c8f965dfe0eb1e23eef88e:2"];
+                            "--utxos","87345e46bfd702d24d54890cc094d08a005f773b27c8f965dfe0eb1e23eef88e:2",
+                            "--add_string","Hello BDK",
+                           ];
 
         let cli_opts = CliOpts::from_iter(&cli_args);
 
@@ -1016,6 +1034,8 @@ mod test {
                     fee_rate: None,
                     external_policy: None,
                     internal_policy: None,
+                    add_data: None,
+                    add_string: Some("Hello BDK".to_string()),
                 }),
             },
         };

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -122,6 +122,8 @@ where
             fee_rate,
             external_policy,
             internal_policy,
+            add_data,
+            add_string,
         } => {
             let mut tx_builder = wallet.build_tx();
 
@@ -149,6 +151,13 @@ where
 
             if let Some(unspendable) = unspendable {
                 tx_builder.unspendable(unspendable);
+            }
+
+            if let Some(base64_data) = add_data {
+                let op_return_data = base64::decode(&base64_data).unwrap();
+                tx_builder.add_data(op_return_data.as_slice());
+            } else if let Some(string_data) = add_string {
+                tx_builder.add_data(string_data.as_bytes());
             }
 
             let policies = vec![


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This enables users to send an arbitrary string message through a txn-output. The maximum size of this string-literal can be length of 80-bytes. 
<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
