### PR TITLE
Migrate from structopt to clap.

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -80,7 +80,7 @@ jobs:
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain
-        run: rustup default 1.56.1 # MSRV
+        run: rustup default 1.57.0 # MSRV
       - name: Set profile
         run: rustup set profile minimal
       - name: Add target wasm32

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - 1.60.0 # STABLE
-          - 1.56.0 # MSRV
+          - 1.57.0 # MSRV
         features:
           - default
           - electrum,sqlite-db

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,15 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +125,7 @@ dependencies = [
  "bdk",
  "bdk-macros",
  "bdk-reserves",
+ "clap",
  "dirs-next",
  "electrsd",
  "env_logger",
@@ -147,7 +139,6 @@ dependencies = [
  "secp256k1 0.22.1",
  "serde",
  "serde_json",
- "structopt",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -382,17 +373,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -885,12 +900,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1317,6 +1329,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -2115,33 +2133,9 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -2190,12 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -2462,12 +2453,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -1332,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "parking_lot"
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 [dependencies]
 bdk = { version = "0.24", default-features = false, features = ["all-keys"] }
 bdk-macros = "0.6"
-structopt = "0.3"
+clap = { version = "3.2.22", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 zeroize = "<1.4.0"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -179,7 +179,7 @@ pub enum WalletSubCommand {
 }
 
 /// Config options wallet operations can take.
-#[derive(Debug, Args, Clone, PartialEq)]
+#[derive(Debug, Parser, Clone, PartialEq)]
 pub struct WalletOpts {
     /// Selects the wallet to use.
     #[clap(name = "WALLET_NAME", short = 'w', long = "wallet")]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,19 +13,19 @@
 //! All subcommands are defined in the below enums.
 
 #![allow(clippy::large_enum_variant)]
-use clap::{AppSettings, Args, Parser, Subcommand};
+use clap::{AppSettings, Parser, Subcommand};
 
 use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey};
 use bdk::bitcoin::{Address, Network, OutPoint, Script};
 
+use crate::utils::{parse_outpoint, parse_recipient};
 #[cfg(any(
     feature = "compact_filters",
     feature = "electrum",
     feature = "esplora",
     feature = "rpc"
 ))]
-use crate::utils::parse_proxy_auth;
-use crate::utils::{parse_outpoint, parse_recipient};
+use {crate::utils::parse_proxy_auth, clap::Args};
 
 #[derive(PartialEq, Clone, Debug, Parser)]
 /// The BDK Command Line Wallet App

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -631,7 +631,6 @@ mod test {
     #[cfg(feature = "repl")]
     use regex::Regex;
 
-
     #[test]
     fn test_clap_args() {
         use clap::CommandFactory;
@@ -863,7 +862,7 @@ mod test {
                             "--change_descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)",
                             "--proxy", "127.0.0.1:9005",
                             "--proxy_auth", "random_user:random_passwd",
-                            "--node", "127.0.0.1:18444", "127.2.3.1:19695",
+                            "--node", "127.0.0.1:18444",
                             "--conn_count", "4",
                             "--skip_blocks", "5",
                             "get_new_address"];
@@ -880,7 +879,7 @@ mod test {
                     descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
                     change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
                     compactfilter_opts: CompactFilterOpts{
-                        address: vec!["127.0.0.1:18444".to_string(), "127.2.3.1:19695".to_string()],
+                        address: vec!["127.0.0.1:18444".to_string()],
                         conn_count: 4,
                         skip_blocks: 5,
                     },

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -272,7 +272,7 @@ where
             let mut psbts = psbt
                 .iter()
                 .map(|s| {
-                    let psbt = base64::decode(&s).map_err(|e| Error::Generic(e.to_string()))?;
+                    let psbt = base64::decode(s).map_err(|e| Error::Generic(e.to_string()))?;
                     let psbt: PartiallySignedTransaction = deserialize(&psbt)?;
                     Ok(psbt)
                 })

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -124,21 +124,12 @@ where
             add_data,
             add_string,
         } => {
-            // Handle string to recipient parsing
-            let parsed_recipients = recipients
-                .iter()
-                .map(|recpt| parse_recipient(recpt))
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(Error::Generic)?;
-
             let mut tx_builder = wallet.build_tx();
 
             if send_all {
-                tx_builder
-                    .drain_wallet()
-                    .drain_to(parsed_recipients[0].0.clone());
+                tx_builder.drain_wallet().drain_to(recipients[0].0.clone());
             } else {
-                tx_builder.set_recipients(parsed_recipients);
+                tx_builder.set_recipients(recipients);
             }
 
             if enable_rbf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use crate::commands::CliOpts;
 use crate::handlers::*;
 use bdk::{bitcoin, Error};
 use bdk_macros::{maybe_async, maybe_await};
-use structopt::StructOpt;
+use clap::Parser;
 
 #[cfg(any(feature = "repl", target_arch = "wasm32"))]
 const REPL_LINE_SPLIT_REGEX: &str = r#""([^"]*)"|'([^']*)'|([\w\-]+)"#;
@@ -36,7 +36,7 @@ const REPL_LINE_SPLIT_REGEX: &str = r#""([^"]*)"|'([^']*)'|([\w\-]+)"#;
 fn main() {
     env_logger::init();
 
-    let cli_opts: CliOpts = CliOpts::from_args();
+    let cli_opts: CliOpts = CliOpts::parse();
 
     let network = cli_opts.network;
     debug!("network: {:?}", network);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -9,6 +9,7 @@ use bitcoin::*;
 use bdk::blockchain::AnyBlockchain;
 use bdk::database::AnyDatabase;
 use bdk::miniscript::{MiniscriptKey, Translator};
+use clap::Parser;
 use js_sys::Promise;
 use regex::Regex;
 use std::collections::HashMap;
@@ -17,7 +18,6 @@ use std::ops::Deref;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::str::FromStr;
-use structopt::StructOpt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes #113.

This is an attempt to migrate from `structopt` to `clap v0.3` which provides very similar kind of derives as `structopt`. Changes are straight forward. But this comes with few more problems. 

 - with clap `v3.2.22` the MSRV pushes up to `1.57.0`.. The last clap of MSRV `1.56.0` was `clap 3.2.5`.. But even that doesn't seem to be working at MSRV `1.56.0` anymore, as bunch of underlying lib has upgraded. 
 
 - `clap v3.0` doesn't seem to support custom vector parsing well, reported here https://github.com/clap-rs/clap/issues/1704. This is required for `recipient` parsing which is a `Vec<(Script, u32)>`.  Workaround for that is to use vecs of strings and parse them at runtime in `create_tx` handler. Included in the PR.    

### Notes to the reviewers

`structopt` is currently freezed at `clap 2.0` and doesn't seem to intend on updating and currently its has unmaintained vulnerability. And `clap v3.0` onward seems to replacing everything that `structopt` did before.  So this means we should also look for ways to migrate from `strcutopt` to `clap`.. But `clap` seemed to have moved ahead than our MSRV `1.56.0`.. So we need to take up a call on that.. Opened this PR to facilitate that discussion..

This is draft until we figure what to do..   

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing