### PR TITLE
bump stable rustc version to 1.65

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # STABLE
+          - 1.65.0 # STABLE
           - 1.57.0 # MSRV
         features:
           - default

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -144,7 +144,7 @@ pub enum CliSubCommand {
 }
 
 /// Backend Node operation subcommands.
-#[derive(Debug, Subcommand, Clone, PartialEq)]
+#[derive(Debug, Subcommand, Clone, PartialEq, Eq)]
 #[clap(rename_all = "lower")]
 #[cfg(any(feature = "regtest-node"))]
 pub enum NodeSubCommand {
@@ -179,7 +179,7 @@ pub enum WalletSubCommand {
 }
 
 /// Config options wallet operations can take.
-#[derive(Debug, Parser, Clone, PartialEq)]
+#[derive(Debug, Parser, Clone, PartialEq, Eq)]
 pub struct WalletOpts {
     /// Selects the wallet to use.
     #[clap(name = "WALLET_NAME", short = 'w', long = "wallet")]
@@ -212,7 +212,7 @@ pub struct WalletOpts {
 
 /// Options to configure a SOCKS5 proxy for a blockchain client connection.
 #[cfg(any(feature = "compact_filters", feature = "electrum", feature = "esplora"))]
-#[derive(Debug, Args, Clone, PartialEq)]
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct ProxyOpts {
     /// Sets the SOCKS5 proxy for a blockchain client.
     #[clap(name = "PROXY_ADDRS:PORT", long = "proxy", short = 'p')]
@@ -234,7 +234,7 @@ pub struct ProxyOpts {
 
 /// Options to configure a BIP157 Compact Filter backend.
 #[cfg(feature = "compact_filters")]
-#[derive(Debug, Args, Clone, PartialEq)]
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct CompactFilterOpts {
     /// Sets the full node network address.
     #[clap(
@@ -261,7 +261,7 @@ pub struct CompactFilterOpts {
 
 /// Options to configure a bitcoin core rpc backend.
 #[cfg(feature = "rpc")]
-#[derive(Debug, Args, Clone, PartialEq)]
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct RpcOpts {
     /// Sets the full node address for rpc connection.
     #[clap(
@@ -298,7 +298,7 @@ pub struct RpcOpts {
 
 /// Options to configure electrum backend.
 #[cfg(feature = "electrum")]
-#[derive(Debug, Args, Clone, PartialEq)]
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct ElectrumOpts {
     /// Sets the SOCKS5 proxy timeout for the Electrum client.
     #[clap(name = "PROXY_TIMEOUT", short = 't', long = "timeout")]
@@ -324,7 +324,7 @@ pub struct ElectrumOpts {
 
 /// Options to configure Esplora backend.
 #[cfg(feature = "esplora")]
-#[derive(Debug, Args, Clone, PartialEq)]
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct EsploraOpts {
     /// Use the esplora server if given as parameter.
     #[clap(
@@ -477,7 +477,7 @@ pub enum OfflineWalletSubCommand {
 }
 
 /// Wallet subcommands that needs a blockchain backend.
-#[derive(Debug, Subcommand, Clone, PartialEq)]
+#[derive(Debug, Subcommand, Clone, PartialEq, Eq)]
 #[clap(rename_all = "snake")]
 #[cfg(any(
     feature = "electrum",
@@ -530,7 +530,7 @@ pub enum OnlineWalletSubCommand {
 }
 
 /// Subcommands for Key operations.
-#[derive(Debug, Subcommand, Clone, PartialEq)]
+#[derive(Debug, Subcommand, Clone, PartialEq, Eq)]
 pub enum KeySubCommand {
     /// Generates new random seed mnemonic phrase and corresponding master extended key.
     Generate {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -747,18 +747,18 @@ pub(crate) fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
     result.map_err(|e| e.into())
 }
 
+#[cfg(any(
+    feature = "electrum",
+    feature = "esplora",
+    feature = "compact_filters",
+    feature = "rpc"
+))]
 #[cfg(test)]
 mod test {
     use super::*;
     use bdk::bitcoin::psbt::PartiallySignedTransaction;
     use std::str::FromStr;
 
-    #[cfg(any(
-        feature = "electrum",
-        feature = "esplora",
-        feature = "compact_filters",
-        feature = "rpc"
-    ))]
     #[test]
     fn test_psbt_is_final() {
         let unsigned_psbt = PartiallySignedTransaction::from_str("cHNidP8BAIkBAAAAASWJHzxzyVORV/C3lAynKHVVL7+Rw7/Jj8U9fuvD24olAAAAAAD+////AiBOAAAAAAAAIgAgLzY9yE4jzTFJnHtTjkc+rFAtJ9NB7ENFQ1xLYoKsI1cfqgKVAAAAACIAIFsbWgDeLGU8EA+RGwBDIbcv4gaGG0tbEIhDvwXXa/E7LwEAAAABALUCAAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////BALLAAD/////AgD5ApUAAAAAIgAgWxtaAN4sZTwQD5EbAEMhty/iBoYbS1sQiEO/Bddr8TsAAAAAAAAAACZqJKohqe3i9hw/cdHe/T+pmd+jaVN1XGkGiXmZYrSL69g2l06M+QEgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQErAPkClQAAAAAiACBbG1oA3ixlPBAPkRsAQyG3L+IGhhtLWxCIQ78F12vxOwEFR1IhA/JV2U/0pXW+iP49QcsYilEvkZEd4phmDM8nV8wC+MeDIQLKhV/gEZYmlsQXnsL5/Uqv5Y8O31tmWW1LQqIBkiqzCVKuIgYCyoVf4BGWJpbEF57C+f1Kr+WPDt9bZlltS0KiAZIqswkEboH3lCIGA/JV2U/0pXW+iP49QcsYilEvkZEd4phmDM8nV8wC+MeDBDS6ZSEAACICAsqFX+ARliaWxBeewvn9Sq/ljw7fW2ZZbUtCogGSKrMJBG6B95QiAgPyVdlP9KV1voj+PUHLGIpRL5GRHeKYZgzPJ1fMAvjHgwQ0umUhAA==").unwrap();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

As BDK bumped its stable to 1.65, it is safe for us to move it up also.  

### Notes to the reviewers

`1.65` cause clippy warning that `Eq` isn't derived while `PartialEq` is derived for the commands. We can't derive `Eq` for commands, as there is a `fee_rate` which is `f32` which isn't `Eq`, and this effect cascades to all structures. We also need `PartialEq` for the tests.

A few options were:
 - allow the clippy warning conditionally for `1.65`, `1.57` doesn't have that lint. The way to do that is by creating custom features for different versions and making a build script that activates specific features for specific versions. Feature gate the clippy lint. or use https://github.com/dtolnay/rustversion which is an extra dep.
 
  - Remove `PartialEq` and create a method on `CliOpts` to translate it into `Vec<String>`, and then perform the tests. 
  
  - Make `fee_rate` `u32` and derive `Eq` for all.
  
I went for the last option as it seemed less complex, and not too bad(?). For bdk_cli as majorly a testing tool, it might not need floating point granularity and users can still test out with `u32` fee_rates. Internally it converts it back to `f32`. 

Suggestions welcome.   
  

## Changelog notice

 - Bumped rustc `stable` to 1.65.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing