### PR TITLE
Fix exit code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,8 @@ async fn main() {
     match handle_command(cli_opts).await {
         Ok(result) => println!("{}", result),
         Err(e) => {
-            error!("{}", e)
+            error!("{}", e);
+            std::process::exit(1);
         }
     }
 }


### PR DESCRIPTION
Fixes #170

I think this is the simplest way to do it.
It's also possible to change the main signature to return `Result`, which should provide similar behavior, but this option isn't compatible with the `#[maybe_async]` macro, so I decided not to complicate things.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
