### PR TITLE
Implement transaction broadcasting for Kyoto

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -239,7 +239,7 @@ pub struct ProxyOpts {
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct CompactFilterOpts {
     /// Sets the number of parallel node connections.
-    #[clap(name = "CONNECTIONS", long = "cbf-conn-count", default_value = "4", value_parser = value_parser!(u8).range(1..=15))]
+    #[clap(name = "CONNECTIONS", long = "cbf-conn-count", default_value = "2", value_parser = value_parser!(u8).range(1..=15))]
     pub conn_count: u8,
 
     /// Optionally skip initial `skip_blocks` blocks.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use bdk_wallet::bitcoin::hex::HexToBytesError;
+use bdk_wallet::bitcoin::psbt::ExtractTxError;
 use bdk_wallet::bitcoin::{base64, consensus};
 use thiserror::Error;
 
@@ -51,7 +52,7 @@ pub enum BDKCliError {
     ParseOutPointError(#[from] bdk_wallet::bitcoin::blockdata::transaction::ParseOutPointError),
 
     #[error("PsbtExtractTxError: {0}")]
-    PsbtExtractTxError(#[from] bdk_wallet::bitcoin::psbt::ExtractTxError),
+    PsbtExtractTxError(Box<ExtractTxError>),
 
     #[error("PsbtError: {0}")]
     PsbtError(#[from] bdk_wallet::bitcoin::psbt::Error),
@@ -89,4 +90,10 @@ pub enum BDKCliError {
     #[cfg(feature = "cbf")]
     #[error("BDK-Kyoto error: {0}")]
     BuilderError(#[from] bdk_kyoto::builder::BuilderError),
+}
+
+impl From<ExtractTxError> for BDKCliError {
+    fn from(value: ExtractTxError) -> Self {
+        BDKCliError::PsbtExtractTxError(Box::new(value))
+    }
 }


### PR DESCRIPTION
The actual implementation comes down to listening for an info message that reports the transaction was sent to a peer. For simplicity I am ignoring any wallet updates, but if the user calls the `Sync` command they can catch them. Follows up #181 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
