### PR TITLE
chore(cbf): set kyoto client data dir

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -154,6 +154,7 @@ pub(crate) enum BlockchainClient {
 pub(crate) fn new_blockchain_client(
     wallet_opts: &WalletOpts,
     wallet: &Wallet,
+    datadir: Option<std::path::PathBuf>,
 ) -> Result<BlockchainClient, Error> {
     #[cfg(any(feature = "electrum", feature = "esplora", feature = "rpc"))]
     let url = wallet_opts.url.as_str();
@@ -199,7 +200,12 @@ pub(crate) fn new_blockchain_client(
                 None => Sync,
             };
 
-            let client = NodeBuilder::new(wallet.network())
+            let mut builder = NodeBuilder::new(wallet.network());
+
+            if let Some(datadir) = datadir {
+                builder = builder.data_dir(&datadir);
+            };
+            let client = builder
                 .required_peers(wallet_opts.compactfilter_opts.conn_count)
                 .build_with_wallet(wallet, scan_type)?;
 


### PR DESCRIPTION

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR set the data directory for the Kyoto client. See [comment](https://github.com/bitcoindevkit/bdk-cli/pull/181#issuecomment-2863853425)

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

This PR ensures that the `light_client_data` directory created by the Kyoto client is in the wallet's data directory.

## Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`


