### PR TITLE
Add Justfile command runner

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,97 @@
+set quiet := true
+msrv := "1.75.0"
+default_wallet := 'regtest_default_wallet'
+default_datadir := "$HOME/.bdk-bitcoin"
+rpc_user := 'user'
+rpc_password := 'password'
+
+# list of recipes
+default:
+  just --list
+
+# format the project code
+fmt:
+    cargo fmt
+
+# lint the project
+clippy: fmt
+    cargo clippy --all-features --tests
+
+# build the project
+build: fmt
+    cargo build --all-features --tests 
+
+# test the project
+test:
+    cargo test --all-features --tests 
+
+# clean the project target directory
+clean:
+    cargo clean
+
+# set the rust version to stable
+stable: clean
+    rustup override set stable; cargo update
+
+# set the rust version to the msrv and pin dependencies
+msrv: clean
+    rustup override set {{msrv}}; cargo update; ./ci/pin-msrv.sh
+
+# start regtest bitcoind in default data directory
+[group('rpc')]
+start:
+    if [ ! -d "{{default_datadir}}" ]; then \
+        mkdir -p "{{default_datadir}}"; \
+    fi
+    bitcoind -datadir={{default_datadir}} -regtest -server -fallbackfee=0.0002 -blockfilterindex=1 -peerblockfilters=1 \
+     -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -daemon
+
+# stop regtest bitcoind
+[group('rpc')]
+stop:
+    pkill bitcoind
+
+# stop and delete regtest bitcoind data
+[group('rpc')]
+reset: stop
+    rm -rf {{default_datadir}}
+
+[group('rpc')]
+create wallet=default_wallet:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} createwallet {{wallet}}
+
+# load regtest wallet
+[group('rpc')]
+load wallet=default_wallet:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} loadwallet {{wallet}}
+
+# unload regtest wallet
+[group('rpc')]
+unload wallet=default_wallet:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} unloadwallet {{wallet}}
+
+
+# get regtest wallet address
+[group('rpc')]
+address wallet=default_wallet:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcwallet={{wallet}} -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} getnewaddress
+
+# generate n new blocks to given address
+[group('rpc')]
+generate n address:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} generatetoaddress {{n}} {{address}}
+
+# get regtest wallet balance
+[group('rpc')]
+balance wallet=default_wallet:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcwallet={{wallet}} -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} getbalance 
+
+# send n btc to address from wallet
+[group('rpc')]
+send n address wallet=default_wallet:
+    bitcoin-cli -named -datadir={{default_datadir}} -regtest -rpcwallet={{wallet}} -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} sendtoaddress address={{address}} amount={{n}}
+
+# list wallet descriptors info, private = (true | false)
+[group('rpc')]
+descriptors private wallet=default_wallet:
+    bitcoin-cli -datadir={{default_datadir}} -regtest -rpcwallet={{wallet}} -rpcuser={{rpc_user}} -rpcpassword={{rpc_password}} listdescriptors {{private}}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ To generate a new extended master key, suitable for use in a descriptor:
 cargo run -- key generate
 ```
 
+## Justfile
+
+We have added the `just` command runner to help you with common commands (during development) and running regtest `bitcoind` if you are using the `rpc` feature. 
+Visit the [just](https://just.systems/man/en/packages.html) page for setup instructions.
+
+The below are some of the commands included:
+
+``` shell
+just # list all available recipes
+just start # start regtest bitcoind in default dir
+just test # test the project
+just build # build the project
+```
+
+
 ## Minimum Supported Rust Version (MSRV)
 
 This library should always compile with any valid combination of features on Rust **1.75.0**.


### PR DESCRIPTION
### Description

This PR adds Justfile config file for the just command runner.

### Notes to the reviewers

The default values for `datadir`, `rpcuser` and `rpcpassword` set in the Justfile are those used in the project.  

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`