### PR TITLE
Kyoto: Remove connection requirement to send tx

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -576,19 +576,10 @@ pub(crate) async fn handle_online_wallet_subcommand(
                         }
                     });
                     let txid = tx.compute_txid();
-                    tracing::info!("Waiting for connections to broadcast...");
-                    while let Some(info) = info_subscriber.recv().await {
-                        match info {
-                            Info::ConnectionsMet => {
-                                requester
-                                    .broadcast_random(tx.clone())
-                                    .map_err(|e| Error::Generic(format!("{}", e)))?;
-                                break;
-                            }
-                            _ => tracing::info!("{info}"),
-                        }
-                    }
-                    tokio::time::timeout(tokio::time::Duration::from_secs(15), async move {
+                    requester
+                        .broadcast_random(tx.clone())
+                        .map_err(|e| Error::Generic(format!("{}", e)))?;
+                    tokio::time::timeout(tokio::time::Duration::from_secs(30), async move {
                         while let Some(info) = info_subscriber.recv().await {
                             match info {
                                 Info::TxGossiped(wtxid) => {
@@ -606,7 +597,7 @@ pub(crate) async fn handle_online_wallet_subcommand(
                     .await
                     .map_err(|_| {
                         tracing::warn!("Broadcast was unsuccessful");
-                        Error::Generic("Transaction broadcast timed out after 15 seconds".into())
+                        Error::Generic("Transaction broadcast timed out after 30 seconds".into())
                     })?;
                     txid
                 }


### PR DESCRIPTION
Kyoto now holds on to a transaction internally until it is successfully broadcast, so we can broadcast the transaction immediately once the node starts up, and wait for a confirmation or 30 second timeout

Successful test on Signet. Note that `Testnet4` still has the difficulty adjustment bug when loading block headers from storage.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
