### PR TITLE
Update `compile` command to support creating taproot descriptors

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -94,7 +94,7 @@ pub enum CliSubCommand {
         #[arg(env = "POLICY", required = true, index = 1)]
         policy: String,
         /// Sets the script type used to embed the compiled policy.
-        #[arg(env = "TYPE", short = 't', long = "type", default_value = "wsh", value_parser = ["sh","wsh", "sh-wsh"]
+        #[arg(env = "TYPE", short = 't', long = "type", default_value = "wsh", value_parser = ["sh","wsh", "sh-wsh", "tr"]
         )]
         script_type: String,
     },

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -338,7 +338,7 @@ pub async fn sync_kyoto_client(wallet: &mut Wallet, client: Box<LightClient>) ->
 
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber)
-        .map_err(|e| Error::Generic(format!("SetGlobalDefault error: {}", e)))?;
+        .map_err(|e| Error::Generic(format!("SetGlobalDefault error: {e}")))?;
 
     tokio::task::spawn(async move { node.run().await });
     tokio::task::spawn(async move {
@@ -355,7 +355,7 @@ pub async fn sync_kyoto_client(wallet: &mut Wallet, client: Box<LightClient>) ->
     tracing::info!("Received update: applying to wallet");
     wallet
         .apply_update(update)
-        .map_err(|e| Error::Generic(format!("Failed to apply update: {}", e)))?;
+        .map_err(|e| Error::Generic(format!("Failed to apply update: {e}")))?;
 
     tracing::info!(
         "Chain tip: {}, Transactions: {}, Balance: {}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -127,19 +127,19 @@ mod test {
                 node_datadir,
             };
 
-            println!("BDK-CLI Config : {:#?}", bdk_cli);
+            println!("BDK-CLI Config : {bdk_cli:#?}");
             let bdk_master_key = bdk_cli.key_exec(&["generate"])?;
             let bdk_xprv = get_value(&bdk_master_key, "xprv")?;
 
             let bdk_recv_desc =
                 bdk_cli.key_exec(&["derive", "--path", "m/84h/1h/0h/0", "--xprv", &bdk_xprv])?;
             let bdk_recv_desc = get_value(&bdk_recv_desc, "xprv")?;
-            let bdk_recv_desc = format!("wpkh({})", bdk_recv_desc);
+            let bdk_recv_desc = format!("wpkh({bdk_recv_desc})");
 
             let bdk_chng_desc =
                 bdk_cli.key_exec(&["derive", "--path", "m/84h/1h/0h/1", "--xprv", &bdk_xprv])?;
             let bdk_chng_desc = get_value(&bdk_chng_desc, "xprv")?;
-            let bdk_chng_desc = format!("wpkh({})", bdk_chng_desc);
+            let bdk_chng_desc = format!("wpkh({bdk_chng_desc})");
 
             bdk_cli.recv_desc = Some(bdk_recv_desc);
             bdk_cli.chang_desc = Some(bdk_chng_desc);


### PR DESCRIPTION
### Description
Resolves #204.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers
For creating the tr descriptor, I used the NUMS pubkey proposed in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs).

There is [discussion](https://github.com/rust-bitcoin/rust-bitcoin/issues/1322) about adding NUMS key to `rust-bicoin`, we can use it in the future from there.

Also there is [BIP draft](https://github.com/bitcoin/bips/pull/1746) for new descriptor key expression `unspendable()` for exacly this use case - we will simply use descriptor `tr(unspendable(), TREE)`.

## Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

