### PR TITLE
Update `bdk_kyoto` to `0.15.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,12 +259,12 @@ dependencies = [
 
 [[package]]
 name = "bdk_kyoto"
-version = "0.13.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb33172976f7fa26115ad6842f7903a2af325544eac6ddf5a17099e3cd9df3c"
+checksum = "91b430c5fc2d28073df2fe122b177e89f67fbcec47824587163ba96499e3d02c"
 dependencies = [
  "bdk_wallet",
- "kyoto-cbf",
+ "bip157",
 ]
 
 [[package]]
@@ -326,6 +326,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip157"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10c525b8dc2a9c0aae5d2de384336696023e5201c6bcc22c47ec0fb9d9947cb"
+dependencies = [
+ "bip324",
+ "bitcoin",
+ "bitcoin-address-book",
+ "tokio",
+]
+
+[[package]]
 name = "bip324"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +378,15 @@ dependencies = [
  "hex_lit",
  "secp256k1",
  "serde",
+]
+
+[[package]]
+name = "bitcoin-address-book"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d55a2ccdaa0271ea60355a01fc82e37f33a340df80599d344f9d6e97d46e48"
+dependencies = [
+ "bitcoin",
 ]
 
 [[package]]
@@ -1353,18 +1374,6 @@ dependencies = [
  "minreq",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "kyoto-cbf"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805f16bcf1d4738529f230404e7d0ab6e9ecf9e265920c212d446a291a93297e"
-dependencies = [
- "bip324",
- "bitcoin",
- "rusqlite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cli-table = "0.5.0"
 bdk_bitcoind_rpc = { version = "0.21.0", features = ["std"], optional = true }
 bdk_electrum = { version = "0.23.0", optional = true }
 bdk_esplora = { version = "0.22.1", features = ["async-https", "tokio"], optional = true }
-bdk_kyoto = { version = "0.13.1", optional = true }
+bdk_kyoto = { version = "0.15.1", optional = true }
 bdk_redb = { version = "0.1.0", optional = true }
 shlex = {  version = "1.3.0", optional = true }
 tracing = "0.1.41"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -247,10 +247,6 @@ pub struct CompactFilterOpts {
     /// Sets the number of parallel node connections.
     #[clap(name = "CONNECTIONS", long = "cbf-conn-count", default_value = "2", value_parser = value_parser!(u8).range(1..=15))]
     pub conn_count: u8,
-
-    /// Optionally skip initial `skip_blocks` blocks.
-    #[clap(env = "SKIP_BLOCKS", short = 'k', long = "cbf-skip-blocks")]
-    pub skip_blocks: Option<u32>,
 }
 
 /// Wallet subcommands that can be issued without a blockchain backend.


### PR DESCRIPTION
Checkpoints were removed from Kyoto to minimize trust in the library and reduce maintence burden. As such, there is no longer the ability to "skip blocks", at least on test networks. Mainnet offers two checkpoints, segwit and taproot activation, but these are included from genesis on test networks.

Broadcasting a transaction now awaits for the transaction to be gossiped, simplifying the logic here.
