### PR TITLE
feat(compile): compile taproot descriptor with randomized unspendable internal key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,8 @@ Every new feature should be covered by functional tests where possible.
 When refactoring, structure your PR to make it easy to review and don't
 hesitate to split it into multiple small, focused PRs.
 
-The Minimal Supported Rust Version is 1.45 (enforced by our CI).
-
 Commits should cover both the issue fixed and the solution's rationale.
-These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind.
+These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind. Commit messages follow the ["Conventional Commits 1.0.0"](https://www.conventionalcommits.org/en/v1.0.0/) to make commit histories easier to read by humans and automated tools. All commits must be [GPG signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 To facilitate communication with other contributors, the project is making use
 of GitHub's "assignee" field. First check that no one is assigned and then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "tap",
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.0+spec-1.1.0",
@@ -2634,6 +2635,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "bdk_redb",
  "bdk_sp",
  "bdk_wallet",
+ "claims",
  "clap",
  "clap_complete",
  "cli-table",
@@ -719,6 +720,12 @@ dependencies = [
  "inout",
  "zeroize",
 ]
+
+[[package]]
+name = "claims"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba18ee93d577a8428902687bcc2b6b45a56b1981a1f6d779731c86cc4c5db18"
 
 [[package]]
 name = "clap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.20"
 toml = "1.1.0"
 serde= {version = "1.0", features = ["derive"]}
+shlex = "1.3.0"
 
 # Optional dependencies
 bdk_bitcoind_rpc = { version = "0.21.0", features = ["std"], optional = true }
@@ -34,7 +35,6 @@ bdk_esplora = { version = "0.22.1", features = ["async-https", "tokio"], optiona
 bdk_kyoto = { version = "0.15.4", optional = true }
 bdk_redb = { version = "0.1.1", optional = true }
 bdk_sp = { version = "0.1.0", optional = true, git = "https://github.com/bitcoindevkit/bdk-sp", tag = "v0.1.0" }
-shlex = {  version = "1.3.0", optional = true }
 payjoin = { version = "=1.0.0-rc.1", features = ["v1", "v2", "io", "_test-utils"], optional = true}
 reqwest = { version = "0.13.2", default-features = false, optional = true }
 url = { version = "2.5.8", optional = true }
@@ -44,7 +44,7 @@ bdk_bip322 = { version = "0.1.0", optional = true }
 default = ["repl", "sqlite"]
 
 # To use the app in a REPL mode
-repl = ["shlex"]
+repl = []
 
 # Available database options
 sqlite = ["bdk_wallet/rusqlite"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,6 @@ compiler = []
 
 # Experimental silent payment sending capabilities
 silent-payments = ["dep:bdk_sp"]
+
+[dev-dependencies]
+claims = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = "0.3.20"
 toml = "1.1.0"
 serde= {version = "1.0", features = ["derive"]}
 shlex = "1.3.0"
+tap = "1.0.1"
 
 # Optional dependencies
 bdk_bitcoind_rpc = { version = "0.21.0", features = ["std"], optional = true }

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The below are some of the commands included:
 just # list all available recipes
 just test # test the project
 just build # build the project
+just pre-push # run full CI checks locally (tests, clippy, fmt) before pushing
 ```
 
 ### Using `Justfile` to run `bitcoind` as a Client

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,9 @@ pub enum BDKCliError {
     #[error("Miniscript error: {0}")]
     MiniscriptError(#[from] bdk_wallet::miniscript::Error),
 
+    #[error("Miniscript compiler error: {0}")]
+    MiniscriptCompilerError(#[from] bdk_wallet::miniscript::policy::compiler::CompilerError),
+
     #[error("ParseError: {0}")]
     ParseError(#[from] bdk_wallet::bitcoin::address::ParseError),
 
@@ -81,6 +84,10 @@ pub enum BDKCliError {
 
     #[error("Signer error: {0}")]
     SignerError(#[from] bdk_wallet::signer::SignerError),
+
+    #[cfg(feature = "compiler")]
+    #[error("Secp256k1 error: {0}")]
+    Secp256k1Error(#[from] bdk_wallet::bitcoin::secp256k1::Error),
 
     #[cfg(feature = "electrum")]
     #[error("Electrum error: {0}")]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -40,12 +40,18 @@ use bdk_wallet::miniscript::miniscript;
 #[cfg(feature = "sqlite")]
 use bdk_wallet::rusqlite::Connection;
 use bdk_wallet::{KeychainKind, SignOptions, Wallet};
+
 #[cfg(feature = "compiler")]
 use bdk_wallet::{
-    bitcoin::XOnlyPublicKey,
+    bitcoin::{
+        XOnlyPublicKey,
+        key::{Parity, rand},
+        secp256k1::{Scalar, SecretKey},
+    },
     descriptor::{Descriptor, Legacy, Miniscript},
     miniscript::{Tap, descriptor::TapTree, policy::Concrete},
 };
+
 use clap::CommandFactory;
 use cli_table::{Cell, CellStruct, Style, Table, format::Justify};
 use serde_json::json;
@@ -1279,30 +1285,38 @@ pub(crate) fn handle_compile_subcommand(
     pretty: bool,
 ) -> Result<String, Error> {
     let policy = Concrete::<String>::from_str(policy.as_str())?;
-    let legacy_policy: Miniscript<String, Legacy> = policy
-        .compile()
-        .map_err(|e| Error::Generic(e.to_string()))?;
-    let segwit_policy: Miniscript<String, Segwitv0> = policy
-        .compile()
-        .map_err(|e| Error::Generic(e.to_string()))?;
-    let taproot_policy: Miniscript<String, Tap> = policy
-        .compile()
-        .map_err(|e| Error::Generic(e.to_string()))?;
+
+    let legacy_policy: Miniscript<String, Legacy> = policy.compile()?;
+    let segwit_policy: Miniscript<String, Segwitv0> = policy.compile()?;
+    let taproot_policy: Miniscript<String, Tap> = policy.compile()?;
+
+    let mut r = None;
 
     let descriptor = match script_type.as_str() {
         "sh" => Descriptor::new_sh(legacy_policy),
         "wsh" => Descriptor::new_wsh(segwit_policy),
         "sh-wsh" => Descriptor::new_sh_wsh(segwit_policy),
         "tr" => {
-            // For tr descriptors, we use a well-known unspendable key (NUMS point).
-            // This ensures the key path is effectively disabled and only script path can be used.
-            // See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+            // For tr descriptors, we use a randomized unspendable key (H + rG).
+            // This improves privacy by preventing observers from determining if key path spending is disabled.
+            // See BIP-341: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
 
-            let xonly_public_key = XOnlyPublicKey::from_str(NUMS_UNSPENDABLE_KEY_HEX)
-                .map_err(|e| Error::Generic(format!("Invalid NUMS key: {e}")))?;
+            let secp = Secp256k1::new();
+            let r_secret = SecretKey::new(&mut rand::thread_rng());
+            r = Some(r_secret.display_secret().to_string());
+
+            let nums_key = XOnlyPublicKey::from_str(NUMS_UNSPENDABLE_KEY_HEX)?;
+            let nums_point = bdk_wallet::bitcoin::secp256k1::PublicKey::from_x_only_public_key(
+                nums_key,
+                Parity::Even,
+            );
+
+            let internal_key_point = nums_point.add_exp_tweak(&secp, &Scalar::from(r_secret))?;
+            let (xonly_internal_key, _) = internal_key_point.x_only_public_key();
 
             let tree = TapTree::Leaf(Arc::new(taproot_policy));
-            Descriptor::new_tr(xonly_public_key.to_string(), Some(tree))
+
+            Descriptor::new_tr(xonly_internal_key.to_string(), Some(tree))
         }
         _ => {
             return Err(Error::Generic(
@@ -1310,19 +1324,29 @@ pub(crate) fn handle_compile_subcommand(
             ));
         }
     }?;
+
     if pretty {
-        let table = vec![vec![
+        let mut rows = vec![vec![
             "Descriptor".cell().bold(true),
-            descriptor.to_string().cell(),
-        ]]
-        .table()
-        .display()
-        .map_err(|e| Error::Generic(e.to_string()))?;
+            shorten(&descriptor, 32, 29).cell(),
+        ]];
+
+        if let Some(r_value) = &r {
+            rows.push(vec!["r".cell().bold(true), shorten(r_value, 4, 4).cell()]);
+        }
+
+        let table = rows
+            .table()
+            .display()
+            .map_err(|e| Error::Generic(e.to_string()))?;
+
         Ok(format!("{table}"))
     } else {
-        Ok(serde_json::to_string_pretty(
-            &json!({"descriptor": descriptor.to_string()}),
-        )?)
+        let mut output = json!({"descriptor": descriptor});
+        if let Some(r_value) = r {
+            output["r"] = json!(r_value);
+        }
+        Ok(serde_json::to_string_pretty(&output)?)
     }
 }
 
@@ -1994,41 +2018,86 @@ mod test {
     #[cfg(feature = "compiler")]
     #[test]
     fn test_compile_taproot() {
-        use super::{NUMS_UNSPENDABLE_KEY_HEX, handle_compile_subcommand};
+        use super::handle_compile_subcommand;
         use bdk_wallet::bitcoin::Network;
-
-        // Expected taproot descriptors with checksums (using NUMS key from constant)
-        let expected_pk_a = format!("tr({},pk(A))#a2mlskt0", NUMS_UNSPENDABLE_KEY_HEX);
-        let expected_and_ab = format!(
-            "tr({},and_v(v:pk(A),pk(B)))#sfplm6kv",
-            NUMS_UNSPENDABLE_KEY_HEX
-        );
+        use claims::assert_ok;
 
         // Test simple pk policy compilation to taproot
-        let result = handle_compile_subcommand(
+        let json_string = assert_ok!(handle_compile_subcommand(
             Network::Testnet,
             "pk(A)".to_string(),
             "tr".to_string(),
             false,
-        );
-        assert!(result.is_ok());
-        let json_string = result.unwrap();
+        ));
         let json_result: serde_json::Value = serde_json::from_str(&json_string).unwrap();
+
         let descriptor = json_result.get("descriptor").unwrap().as_str().unwrap();
-        assert_eq!(descriptor, expected_pk_a);
+        assert!(descriptor.starts_with("tr("));
+        assert!(descriptor.contains(",pk(A))#"));
+        assert!(json_result.get("r").is_some());
 
         // Test more complex policy
-        let result = handle_compile_subcommand(
+        let json_string = assert_ok!(handle_compile_subcommand(
             Network::Testnet,
             "and(pk(A),pk(B))".to_string(),
             "tr".to_string(),
             false,
-        );
-        assert!(result.is_ok());
-        let json_string = result.unwrap();
+        ));
         let json_result: serde_json::Value = serde_json::from_str(&json_string).unwrap();
+
         let descriptor = json_result.get("descriptor").unwrap().as_str().unwrap();
-        assert_eq!(descriptor, expected_and_ab);
+        assert!(descriptor.starts_with("tr("));
+        assert!(descriptor.contains(",and_v(v:pk(A),pk(B)))#"));
+        assert!(json_result.get("r").is_some());
+    }
+
+    #[cfg(feature = "compiler")]
+    #[test]
+    fn test_compile_non_taproot_has_no_r() {
+        use super::handle_compile_subcommand;
+        use bdk_wallet::bitcoin::Network;
+        use claims::assert_ok;
+
+        let json_string = assert_ok!(handle_compile_subcommand(
+            Network::Testnet,
+            "pk(A)".to_string(),
+            "wsh".to_string(),
+            false,
+        ));
+        let json_result: serde_json::Value = serde_json::from_str(&json_string).unwrap();
+
+        let descriptor = json_result.get("descriptor").unwrap().as_str().unwrap();
+        assert!(descriptor.starts_with("wsh(pk(A))#"));
+        assert!(json_result.get("r").is_none());
+    }
+
+    #[cfg(feature = "compiler")]
+    #[test]
+    fn test_compile_taproot_randomness() {
+        use super::handle_compile_subcommand;
+        use bdk_wallet::bitcoin::Network;
+        use claims::assert_ok;
+
+        // Two compilations of the same policy should produce different internal keys
+        let result1 = assert_ok!(handle_compile_subcommand(
+            Network::Testnet,
+            "pk(A)".to_string(),
+            "tr".to_string(),
+            false,
+        ));
+        let result2 = assert_ok!(handle_compile_subcommand(
+            Network::Testnet,
+            "pk(A)".to_string(),
+            "tr".to_string(),
+            false,
+        ));
+
+        let json1: serde_json::Value = serde_json::from_str(&result1).unwrap();
+        let json2: serde_json::Value = serde_json::from_str(&result2).unwrap();
+
+        let r1 = json1.get("r").unwrap().as_str().unwrap();
+        let r2 = json2.get("r").unwrap().as_str().unwrap();
+        assert_ne!(r1, r2, "Each compilation should produce a unique r value");
     }
 
     #[cfg(feature = "compiler")]
@@ -2036,46 +2105,46 @@ mod test {
     fn test_compile_invalid_cases() {
         use super::handle_compile_subcommand;
         use bdk_wallet::bitcoin::Network;
+        use claims::assert_err;
 
         // Test invalid policy syntax
-        let result = handle_compile_subcommand(
+        assert_err!(handle_compile_subcommand(
             Network::Testnet,
             "invalid_policy".to_string(),
             "tr".to_string(),
             false,
-        );
-        assert!(result.is_err());
+        ));
 
         // Test invalid script type
-        let result = handle_compile_subcommand(
+        assert_err!(handle_compile_subcommand(
             Network::Testnet,
             "pk(A)".to_string(),
             "invalid_type".to_string(),
             false,
-        );
-        assert!(result.is_err());
+        ));
 
         // Test empty policy
-        let result =
-            handle_compile_subcommand(Network::Testnet, "".to_string(), "tr".to_string(), false);
-        assert!(result.is_err());
+        assert_err!(handle_compile_subcommand(
+            Network::Testnet,
+            "".to_string(),
+            "tr".to_string(),
+            false,
+        ));
 
         // Test malformed policy with unmatched parentheses
-        let result = handle_compile_subcommand(
+        assert_err!(handle_compile_subcommand(
             Network::Testnet,
             "pk(A".to_string(),
             "tr".to_string(),
             false,
-        );
-        assert!(result.is_err());
+        ));
 
         // Test policy with unknown function
-        let result = handle_compile_subcommand(
+        assert_err!(handle_compile_subcommand(
             Network::Testnet,
             "unknown_func(A)".to_string(),
             "tr".to_string(),
             false,
-        );
-        assert!(result.is_err());
+        ));
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1983,12 +1983,6 @@ pub fn handle_descriptor_command(
     format_descriptor_output(&result, pretty)
 }
 
-#[cfg(any(
-    feature = "electrum",
-    feature = "esplora",
-    feature = "cbf",
-    feature = "rpc"
-))]
 #[cfg(test)]
 mod test {
     #[cfg(any(

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -48,13 +48,15 @@ use bdk_wallet::{
         key::{Parity, rand},
         secp256k1::{Scalar, SecretKey},
     },
-    descriptor::{Descriptor, Legacy, Miniscript},
+    descriptor::{Descriptor, Legacy},
     miniscript::{Tap, descriptor::TapTree, policy::Concrete},
 };
 
 use clap::CommandFactory;
 use cli_table::{Cell, CellStruct, Style, Table, format::Justify};
 use serde_json::json;
+#[cfg(feature = "compiler")]
+use tap::Pipe;
 #[cfg(feature = "silent-payments")]
 use {
     bdk_sp::{
@@ -1286,16 +1288,12 @@ pub(crate) fn handle_compile_subcommand(
 ) -> Result<String, Error> {
     let policy = Concrete::<String>::from_str(policy.as_str())?;
 
-    let legacy_policy: Miniscript<String, Legacy> = policy.compile()?;
-    let segwit_policy: Miniscript<String, Segwitv0> = policy.compile()?;
-    let taproot_policy: Miniscript<String, Tap> = policy.compile()?;
-
     let mut r = None;
 
     let descriptor = match script_type.as_str() {
-        "sh" => Descriptor::new_sh(legacy_policy),
-        "wsh" => Descriptor::new_wsh(segwit_policy),
-        "sh-wsh" => Descriptor::new_sh_wsh(segwit_policy),
+        "sh" => policy.compile::<Legacy>()?.pipe(Descriptor::new_sh),
+        "wsh" => policy.compile::<Segwitv0>()?.pipe(Descriptor::new_wsh),
+        "sh-wsh" => policy.compile::<Segwitv0>()?.pipe(Descriptor::new_sh_wsh),
         "tr" => {
             // For tr descriptors, we use a randomized unspendable key (H + rG).
             // This improves privacy by preventing observers from determining if key path spending is disabled.
@@ -1314,7 +1312,7 @@ pub(crate) fn handle_compile_subcommand(
             let internal_key_point = nums_point.add_exp_tweak(&secp, &Scalar::from(r_secret))?;
             let (xonly_internal_key, _) = internal_key_point.x_only_public_key();
 
-            let tree = TapTree::Leaf(Arc::new(taproot_policy));
+            let tree = TapTree::Leaf(Arc::new(policy.compile::<Tap>()?));
 
             Descriptor::new_tr(xonly_internal_key.to_string(), Some(tree))
         }


### PR DESCRIPTION
### Description

Part of #218

Implements randomization of the unspendable internal key for taproot descriptors. This is the first part of #218, which consists of two parts:
1. **This PR**: Randomize unspendable internal key for taproot descriptor
2. **Follow-up**: Add verification command to ensure internal key is derived from NUMS key

Split into separate PRs for easier review and iteration, and to allow independent discussion of the verification command implementation, as one of the possible approaches could introduce breaking changes.

### Notes to the reviewers
The `compile` command now returns an additional `r` field for taproot descriptors (`-t tr`), containing the randomly generated internal key. Each compilation will produce a different internal key instead of using a fixed NUMS key.

Example output for taproot (first execution):
```
-> % bdk-cli compile "pk(A)" -t tr
{
  "descriptor": "tr(2dd09dd0355f4b2d5a4886de599786f3c0211652373221c87aba1cd1f7f1e593,pk(A))#anvu48aj",
  "r": "275a58827bd0ad459d6f92e083ddc3d99a03076155691680eb8f3b06380cdcfd"
}
```

Same descriptor compiled again produces different `r` and internal key:
```
-> % bdk-cli compile "pk(A)" -t tr
{
  "descriptor": "tr(801078f69dae7d95631723d4d13e6c32911633d227dcfc24c6b7e32e1e533e6c,pk(A))#f79rr82j",
  "r": "5e3ac63bb20d6a4bfff645279cc63a7472e18066da8826b13cbcb23aecb5c401"
}
```

Other descriptor types remain unchanged:
```
-> % bdk-cli compile "pk(A)" -t sh
{
  "descriptor": "sh(pk(A))#k80zhe7s"
}
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`
