### PR TITLE
Add -p short flag for pretty command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,7 +51,7 @@ pub struct CliOpts {
     #[arg(env = "DATADIR", short = 'd', long = "datadir")]
     pub datadir: Option<std::path::PathBuf>,
     /// Output results in pretty format (instead of JSON).
-    #[arg(long = "pretty", global = true)]
+    #[arg(long = "pretty", short = 'p', global = true)]
     pub pretty: bool,
     /// Top level cli sub-commands.
     #[command(subcommand)]


### PR DESCRIPTION
Add `-p` short flag for `pretty` command

### Description
This PR adds a short `-p` flag as an alias for the existing `--pretty` option to make the command easier and faster to use.

### Notes to the reviewers
The new `-p` flag behaves exactly the same as `--pretty`.  
No existing behavior is changed — this only introduces an additional alias.

## Changelog notice
Added `-p` as a shorthand flag for the `pretty` command.

### Checklists

#### All Submissions:
* [ ] I've run `cargo fmt` and `cargo clippy`
* [ ] I followed the contribution guidelines

#### New Features:
* [ ] I've added docs for the new flag