### PR TITLE
added single-letter aliases for top-level cli commands (issue #229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,30 @@ directly from [crates.io](https://crates.io/crates/bdk-cli) with a command as be
 ```sh
 cargo install bdk-cli --features electrum
 ```
+## Command Aliases
+
+bdk-cli provides short aliases for commonly used commands to improve CLI ergonomics.
+
+### Top-level command aliases
+
+| Command     | Alias |
+|------------|-------|
+| wallet     | W |
+| key        | K |
+| compile    | C |
+| repl       | R |
+| descriptor | D |
+
+### Wallet subcommand aliases
+
+| Command             | Alias |
+|---------------------|-------|
+| new_address         | new_addr |
+| unused_address      | unused_addr |
+| create_tx           | create |
+| bump_fee            | bump |
+| public_descriptor   | pub_desc |
+
 
 ### bdk-cli bin usage examples
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -273,8 +273,10 @@ pub struct CompactFilterOpts {
 #[command(rename_all = "snake")]
 pub enum OfflineWalletSubCommand {
     /// Get a new external address.
+    #[command(alias = "new_addr")]
     NewAddress,
     /// Get the first unused external address.
+    #[command(alias = "unused_addr")]
     UnusedAddress,
     /// Lists the available spendable UTXOs.
     Unspent,
@@ -283,6 +285,7 @@ pub enum OfflineWalletSubCommand {
     /// Returns the current wallet balance.
     Balance,
     /// Creates a new unsigned transaction.
+    #[command(alias = "create")]
     CreateTx {
         /// Adds a recipient to the transaction.
         // Clap Doesn't support complex vector parsing https://github.com/clap-rs/clap/issues/1704.
@@ -331,6 +334,7 @@ pub enum OfflineWalletSubCommand {
         add_data: Option<String>, //base 64 econding
     },
     /// Bumps the fees of an RBF transaction.
+    #[command(alias = "bump")]
     BumpFee {
         /// TXID of the transaction to update.
         #[arg(env = "TXID", long = "txid")]
@@ -359,6 +363,7 @@ pub enum OfflineWalletSubCommand {
     /// Returns the available spending policies for the descriptor.
     Policies,
     /// Returns the public version of the wallet's descriptor(s).
+    #[command(alias = "pub_desc")]
     PublicDescriptor,
     /// Signs and tries to finalize a PSBT.
     Sign {


### PR DESCRIPTION
This PR adds single-letter aliases for top-level CLI commands to improve ergonomics.

Added aliases:
- W → wallet
- K → key
- C → compile
- R → repl
- D → descriptor

No behavior changes; aliases map directly to existing commands.

Closes #229