### PR TITLE
Fix duplicate wallet creation in non-persistent path

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -999,10 +999,9 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
             };
             #[cfg(not(any(feature = "sqlite", feature = "redb")))]
             let result = {
-                let wallet = new_wallet(network, wallet_opts)?;
+                let mut wallet = new_wallet(network, wallet_opts)?;
                 let blockchain_client =
                     crate::utils::new_blockchain_client(wallet_opts, &wallet, database_path)?;
-                let mut wallet = new_wallet(network, wallet_opts)?;
                 handle_online_wallet_subcommand(&mut wallet, blockchain_client, online_subcommand)
                     .await?
             };


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
The non-persistent wallet path (when sqlite/redb features are disabled) was creating the wallet twice: first as immutable to create the blockchain_client, then again as mutable. This caused the blockchain_client to be initialized with the first wallet instance, but then used with the second wallet instance, creating a mismatch.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing



#### Bugfixes:
* [x] I'm linking the issue being fixed by this PR
The PR addresses  https://github.com/bitcoindevkit/bdk-cli/issues/232