### PR TITLE
feat: add BIP353 DNS payment instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-trait"
@@ -204,6 +204,7 @@ dependencies = [
  "bdk_redb",
  "bdk_sp",
  "bdk_wallet",
+ "bitcoin-payment-instructions",
  "claims",
  "clap",
  "clap_complete",
@@ -501,6 +502,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-payment-instructions"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c300c948b2ff78c965ea3a613372352125448a22f1acf49e95e3878149824091"
+dependencies = [
+ "bitcoin",
+ "dnssec-prover",
+ "getrandom 0.3.4",
+ "lightning",
+ "lightning-invoice",
+]
+
+[[package]]
 name = "bitcoin-units"
 version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,9 +629,9 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -658,6 +672,17 @@ dependencies = [
  "cfg-if",
  "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -877,6 +902,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -945,12 +979,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1015,6 +1048,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dnssec-prover"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+dependencies = [
+ "bitcoin_hashes 0.14.101",
+ "tokio",
 ]
 
 [[package]]
@@ -1267,11 +1310,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1281,8 +1322,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1305,6 +1349,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -1735,11 +1785,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -1779,6 +1829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1852,54 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lightning"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a1ab99a13ab3343a9b4d1d25c455bf72322819fc5a5f05c5182e704528a583"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice",
+ "lightning-macros",
+ "lightning-types",
+ "possiblyrandom",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d83bd798e04ab9eecc8bbef1fa17d3808859bcdc0406bd16c55d51c8834444"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c211dfcff95ca308247da8b1e0e81604bc9e568239967cd2c34572558511e869"
+dependencies = [
+ "bitcoin",
 ]
 
 [[package]]
@@ -1833,9 +1937,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniscript"
@@ -2083,6 +2187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "possiblyrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,28 +2211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2153,15 +2244,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls 0.23.41",
@@ -2175,16 +2267,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2215,18 +2307,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2240,16 +2333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,11 +2343,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2431,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2558,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -3436,16 +3525,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3463,31 +3543,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3497,22 +3560,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3521,22 +3572,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3545,22 +3584,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3569,22 +3596,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3629,18 +3644,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,14 +213,14 @@ dependencies = [
  "env_logger",
  "log",
  "payjoin",
- "reqwest 0.13.4",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "shlex 1.3.0",
  "tap",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.1+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -375,7 +375,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.15.0",
  "chacha20-poly1305",
- "rand 0.8.6",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -493,7 +493,7 @@ dependencies = [
  "hkdf 0.11.0",
  "lazy_static",
  "log",
- "rand 0.8.6",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "sha2 0.9.9",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -638,6 +638,12 @@ dependencies = [
  "libc",
  "shlex 2.0.1",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -772,9 +778,9 @@ checksum = "bba18ee93d577a8428902687bcc2b6b45a56b1981a1f6d779731c86cc4c5db18"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -803,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1152,9 +1158,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1368,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1516,14 +1522,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.9"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls 0.23.41",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1571,13 +1578,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1585,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1598,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1612,15 +1618,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1632,15 +1638,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1664,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1674,12 +1680,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1696,6 +1702,16 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1736,32 +1752,27 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.22.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
+ "cesu8",
  "cfg-if",
  "combine",
- "jni-macros",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
- "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "walkdir",
- "windows-link",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
-name = "jni-macros"
-version = "0.22.4"
+name = "jni-sys"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -1824,9 +1835,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -1910,9 +1921,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -2133,9 +2144,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -2179,9 +2190,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -2197,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2302,9 +2313,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -2457,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2525,15 +2536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,7 +2571,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -2598,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2610,11 +2612,11 @@ dependencies = [
  "rustls 0.23.41",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2635,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2698,7 +2700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes 0.14.101",
- "rand 0.8.6",
+ "rand 0.8.5",
  "secp256k1-sys",
  "serde",
 ]
@@ -2736,12 +2738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -2859,22 +2855,6 @@ dependencies = [
  "errno",
  "libc",
 ]
-
-[[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -3026,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3051,9 +3031,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -3068,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3108,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3132,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow",
 ]
@@ -3162,20 +3142,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
- "url",
 ]
 
 [[package]]
@@ -3521,11 +3501,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3539,19 +3528,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3561,9 +3571,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3579,9 +3601,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3591,9 +3625,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3603,9 +3649,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -3615,9 +3661,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
@@ -3664,18 +3710,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3705,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3716,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3727,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ payjoin = { version = "0.25.0", features = ["v1", "v2", "io", "_test-utils"], op
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls"], optional = true }
 url = { version = "2.5.8", optional = true }
 bdk_bip322 = { version = "0.1.0", optional = true }
+bitcoin-payment-instructions = { version = "0.7.0", optional = true}
 
 [features]
 default = ["repl", "sqlite"]
@@ -55,7 +56,8 @@ redb = ["bdk_redb"]
 cbf = ["bdk_kyoto", "_payjoin-dependencies"]
 electrum = ["bdk_electrum", "_payjoin-dependencies"]
 esplora = ["bdk_esplora", "_payjoin-dependencies"]
-rpc = ["bdk_bitcoind_rpc", "_payjoin-dependencies"] 
+rpc = ["bdk_bitcoind_rpc", "_payjoin-dependencies"]
+dns_payment = ["bitcoin-payment-instructions"] 
 
 # Internal features
 _payjoin-dependencies = ["payjoin", "reqwest", "url", "sqlite"]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -380,7 +380,7 @@ pub enum OfflineWalletSubCommand {
         /// Adds a recipient to the transaction.
         // Clap Doesn't support complex vector parsing https://github.com/clap-rs/clap/issues/1704.
         // Address and amount parsing is done at run time in handler function.
-        #[arg(env = "ADDRESS:SAT", long = "to", required = true, value_parser = parse_recipient)]
+        #[arg(env = "ADDRESS:SAT", long = "to", value_parser = parse_recipient)]
         recipients: Vec<(ScriptBuf, u64)>,
         #[cfg(feature = "dns_payment")]
         /// Adds DNS recipients to the transaction

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -389,7 +389,7 @@ pub enum OfflineWalletSubCommand {
         dns_recipients: Vec<(String, u64)>,
         #[cfg(feature = "dns_payment")]
         /// Custom resolver DNS IP to be used for resolution.
-        #[arg(long = "dns_resolver", default_value = "8.8.8.8:53")]
+        #[arg(long = "dns_resolver", default_value = "8.8.8.8")]
         dns_resolver: String,
         /// Sends all the funds (or all the selected utxos). Requires only one recipient with value 0.
         #[arg(long = "send_all", short = 'a')]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -16,7 +16,6 @@
 #[cfg(feature = "silent-payments")]
 use {crate::utils::parse_sp_code_value_pairs, bdk_sp::encoding::SilentPaymentCode};
 
-
 use bdk_wallet::bitcoin::{
     Address, Network, OutPoint, ScriptBuf,
     bip32::{DerivationPath, Xpriv},

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -16,6 +16,7 @@
 #[cfg(feature = "silent-payments")]
 use {crate::utils::parse_sp_code_value_pairs, bdk_sp::encoding::SilentPaymentCode};
 
+
 use bdk_wallet::bitcoin::{
     Address, Network, OutPoint, ScriptBuf,
     bip32::{DerivationPath, Xpriv},
@@ -23,6 +24,8 @@ use bdk_wallet::bitcoin::{
 use clap::{Args, Parser, Subcommand, ValueEnum, value_parser};
 use clap_complete::Shell;
 
+#[cfg(feature = "dns_payment")]
+use crate::utils::parse_dns_recipient;
 #[cfg(any(feature = "electrum", feature = "esplora", feature = "rpc"))]
 use crate::utils::parse_proxy_auth;
 use crate::utils::{parse_address, parse_outpoint, parse_recipient};
@@ -198,6 +201,16 @@ pub enum CliSubCommand {
         #[arg(long = "spend_key")]
         spend: bdk_sp::bitcoin::secp256k1::PublicKey,
     },
+
+    #[cfg(feature = "dns_payment")]
+    /// Resolves BIP-353 DNS payment instructions for a human-readable name.
+    ResolveDnsRecipient {
+        /// Human-readable name (e.g. user@domain.com)
+        hrn: String,
+        /// DNS resolver address
+        #[arg(long, default_value = "8.8.8.8")]
+        resolver: String,
+    },
 }
 
 /// Wallet operation subcommands.
@@ -370,6 +383,14 @@ pub enum OfflineWalletSubCommand {
         // Address and amount parsing is done at run time in handler function.
         #[arg(env = "ADDRESS:SAT", long = "to", required = true, value_parser = parse_recipient)]
         recipients: Vec<(ScriptBuf, u64)>,
+        #[cfg(feature = "dns_payment")]
+        /// Adds DNS recipients to the transaction
+        #[arg(long = "to_dns", value_parser = parse_dns_recipient)]
+        dns_recipients: Vec<(String, u64)>,
+        #[cfg(feature = "dns_payment")]
+        /// Custom resolver DNS IP to be used for resolution.
+        #[arg(long = "dns_resolver", default_value = "8.8.8.8:53")]
+        dns_resolver: String,
         /// Sends all the funds (or all the selected utxos). Requires only one recipient with value 0.
         #[arg(long = "send_all", short = 'a')]
         send_all: bool,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -380,14 +380,57 @@ pub enum OfflineWalletSubCommand {
         /// Adds a recipient to the transaction.
         // Clap Doesn't support complex vector parsing https://github.com/clap-rs/clap/issues/1704.
         // Address and amount parsing is done at run time in handler function.
+        #[arg(env = "ADDRESS:SAT", long = "to", required = true, value_parser = parse_recipient)]
+        recipients: Vec<(ScriptBuf, u64)>,
+        /// Sends all the funds (or all the selected utxos). Requires only one recipient with value 0.
+        #[arg(long = "send_all", short = 'a')]
+        send_all: bool,
+        /// Enables Replace-By-Fee (BIP125).
+        #[arg(long = "enable_rbf", short = 'r', default_value_t = true)]
+        enable_rbf: bool,
+        /// Make a PSBT that can be signed by offline signers and hardware wallets. Forces the addition of `non_witness_utxo` and more details to let the signer identify the change output.
+        #[arg(long = "offline_signer")]
+        offline_signer: bool,
+        /// Selects which utxos *must* be spent.
+        #[arg(env = "MUST_SPEND_TXID:VOUT", long = "utxos", value_parser = parse_outpoint)]
+        utxos: Option<Vec<OutPoint>>,
+        /// Marks a utxo as unspendable.
+        #[arg(env = "CANT_SPEND_TXID:VOUT", long = "unspendable", value_parser = parse_outpoint)]
+        unspendable: Option<Vec<OutPoint>>,
+        /// Fee rate to use in sat/vbyte.
+        #[arg(env = "SATS_VBYTE", short = 'f', long = "fee_rate")]
+        fee_rate: Option<f32>,
+        /// Selects which policy should be used to satisfy the external descriptor.
+        #[arg(env = "EXT_POLICY", long = "external_policy")]
+        external_policy: Option<String>,
+        /// Selects which policy should be used to satisfy the internal descriptor.
+        #[arg(env = "INT_POLICY", long = "internal_policy")]
+        internal_policy: Option<String>,
+        /// Optionally create an OP_RETURN output containing given String in utf8 encoding (max 80 bytes)
+        #[arg(
+            env = "ADD_STRING",
+            long = "add_string",
+            short = 's',
+            conflicts_with = "add_data"
+        )]
+        add_string: Option<String>,
+        /// Optionally create an OP_RETURN output containing given base64 encoded String. (max 80 bytes)
+        #[arg(
+            env = "ADD_DATA",
+            long = "add_data",
+            short = 'o',
+            conflicts_with = "add_string"
+        )]
+        add_data: Option<String>, //base 64 econding
+    },
+    #[cfg(feature = "dns_payment")]
+    /// Creates a new unsigned transaction from DNS payment instructions.
+    CreateDnsTx {
+        /// Adds a recipient to the transaction.
         #[arg(env = "ADDRESS:SAT", long = "to", value_parser = parse_recipient)]
         recipients: Vec<(ScriptBuf, u64)>,
-        #[cfg(feature = "dns_payment")]
-        /// Adds DNS recipients to the transaction
         #[arg(long = "to_dns", value_parser = parse_dns_recipient)]
         dns_recipients: Vec<(String, u64)>,
-        #[cfg(feature = "dns_payment")]
-        /// Custom resolver DNS IP to be used for resolution.
         #[arg(long = "dns_resolver", default_value = "8.8.8.8")]
         dns_resolver: String,
         /// Sends all the funds (or all the selected utxos). Requires only one recipient with value 0.

--- a/src/dns_payment_instructions.rs
+++ b/src/dns_payment_instructions.rs
@@ -1,0 +1,287 @@
+use bdk_wallet::bitcoin::{Address, Amount, Network};
+use bitcoin_payment_instructions::{
+    FixedAmountPaymentInstructions, ParseError, PaymentInstructions, PaymentMethod,
+    PaymentMethodType, amount, dns_resolver::DNSHrnResolver,
+};
+use cli_table::{Cell, Style, Table, format::Justify};
+use core::{net::SocketAddr, str::FromStr};
+
+use crate::{error::BDKCliError as Error, utils::shorten};
+
+#[derive(Debug)]
+pub struct Payment {
+    pub payment_methods: Vec<PaymentMethod>,
+    pub min_amount: Option<Amount>,
+    pub max_amount: Option<Amount>,
+    pub description: Option<String>,
+    pub expected_amount: Option<Amount>,
+    pub receiving_addr: Option<Address>,
+    pub hrn: String,
+    pub notes: String,
+}
+
+impl Payment {
+    pub fn display(&self, pretty: bool) -> Result<String, Error> {
+        let mut methods: Vec<String> = Vec::new();
+        self.payment_methods.iter().for_each(|pm| match pm {
+            bitcoin_payment_instructions::PaymentMethod::LightningBolt11(bolt11) => {
+                methods.push(format!("Bolt 11 invoice ({})", shorten(bolt11, 20, 15)))
+            }
+            bitcoin_payment_instructions::PaymentMethod::LightningBolt12(offer) => {
+                methods.push(format!("Bolt 12 invoice ({})", shorten(offer, 20, 15)))
+            }
+            bitcoin_payment_instructions::PaymentMethod::OnChain(address) => {
+                methods.push(format!("On chain ({})", address))
+            }
+            bitcoin_payment_instructions::PaymentMethod::Cashu(csh) => {
+                methods.push(format!("Cashu payment ({})", shorten(csh, 20, 15)))
+            }
+        });
+
+        if pretty {
+            let mut table = vec![vec![
+                "HRN".cell().bold(true),
+                self.hrn.to_string().cell().justify(Justify::Right),
+            ]];
+
+            if let Some(min_amnt) = self.min_amount {
+                table.push(vec![
+                    "Min amount".cell().bold(true),
+                    min_amnt.to_string().cell().justify(Justify::Right),
+                ]);
+            }
+
+            if let Some(max_amnt) = self.max_amount {
+                table.push(vec![
+                    "Max amount".cell().bold(true),
+                    max_amnt.to_string().cell().justify(Justify::Right),
+                ]);
+            }
+
+            if let Some(send_amnt) = self.expected_amount {
+                table.push(vec![
+                    "Expected Amount to send".cell().bold(true),
+                    send_amnt.to_string().cell().justify(Justify::Right),
+                ]);
+            }
+
+            if let Some(descr) = &self.description {
+                table.push(vec![
+                    "Description".cell().bold(true),
+                    descr.cell().justify(Justify::Right),
+                ]);
+            }
+
+            table.push(vec![
+                "Accepted methods".cell().bold(true),
+                methods.join(", ").cell().justify(Justify::Right),
+            ]);
+            table.push(vec![
+                "Notes".cell().bold(true),
+                self.notes.clone().cell().justify(Justify::Right),
+            ]);
+
+            let table = table
+                .table()
+                .display()
+                .map_err(|e| Error::Generic(e.to_string()))?;
+
+            Ok(format!("{table}"))
+        } else {
+            Ok(serde_json::to_string_pretty(&serde_json::json!({
+                    "hrn": self.hrn,
+                    "payment_methods": methods,
+                    "description": self.description,
+                    "min_amount": self.min_amount,
+                    "max_amount": self.max_amount,
+                    "expected_amount_to_send": self.expected_amount,
+                    "notes": self.notes
+            }))?)
+        }
+    }
+}
+pub(crate) async fn parse_dns_instructions(
+    hrn: &str,
+    network: Network,
+    resolver_ip: String,
+) -> Result<(DNSHrnResolver, PaymentInstructions), ParseError> {
+    let ip_address = if resolver_ip.contains(':') {
+        resolver_ip
+    } else {
+        format!("{resolver_ip}:53")
+    };
+
+    let sock_addr = SocketAddr::from_str(&ip_address).map_err(|_| {
+        ParseError::HrnResolutionError("Unable to create socket from provided address")
+    })?;
+    let resolver = DNSHrnResolver(sock_addr);
+    let instructions = PaymentInstructions::parse(hrn, network, &resolver, true).await?;
+    Ok((resolver, instructions))
+}
+
+fn get_onchain_info(
+    instructions: &FixedAmountPaymentInstructions,
+) -> Result<(Address, Amount), Error> {
+    // Look for on chain payment method as it's the only one we can support
+    let PaymentMethod::OnChain(addr) = instructions
+        .methods()
+        .iter()
+        .find(|ix| matches!(ix, PaymentMethod::OnChain(_)))
+        .ok_or(Error::Generic(
+            "Missing Onchain payment method option.".to_string(),
+        ))?
+    else {
+        return Err(Error::Generic("Unsupported payment method".to_string()));
+    };
+
+    let Some(onchain_amount) = instructions.onchain_payment_amount() else {
+        return Err(Error::Generic(
+            "On chain amount should be specified".to_string(),
+        ));
+    };
+
+    // We need this conversion since Amount from instructions is different from Amount from bitcoin
+    Ok((addr.clone(), Amount::from_sat(onchain_amount.milli_sats())))
+}
+
+pub async fn process_instructions(
+    amount_to_send: Amount,
+    payment_instructions: &PaymentInstructions,
+    resolver: DNSHrnResolver,
+) -> Result<Payment, Error> {
+    match payment_instructions {
+        PaymentInstructions::ConfigurableAmount(instructions) => {
+            // Look for on chain payment method as it's the only one we can support
+            if !instructions
+                .methods()
+                .any(|method| matches!(method.method_type(), PaymentMethodType::OnChain))
+            {
+                return Err(Error::Generic("Unsupported payment method".to_string()));
+            }
+
+            let min_amount = instructions
+                .min_amt()
+                .map(|amnt| Amount::from_sat(amnt.milli_sats()));
+
+            let max_amount = instructions
+                .max_amt()
+                .map(|amnt| Amount::from_sat(amnt.milli_sats()));
+
+            if min_amount.is_some_and(|min| amount_to_send < min) {
+                return Err(Error::Generic(
+                    format!(
+                        "Amount to send should be greater than min {}",
+                        min_amount.unwrap()
+                    )
+                    .to_string(),
+                ));
+            }
+
+            if max_amount.is_some_and(|max| amount_to_send > max) {
+                return Err(Error::Generic(
+                    format!(
+                        "Amount to send should be lower than max {}",
+                        max_amount.unwrap()
+                    )
+                    .to_string(),
+                ));
+            }
+
+            let fixed_instructions = instructions
+                .clone()
+                .set_amount(
+                    amount::Amount::from_sats(amount_to_send.to_sat()).unwrap(),
+                    &resolver,
+                )
+                .await
+                .map_err(|err| {
+                    Error::Generic(format!("Error occured while parsing instructions {err}"))
+                })?;
+
+            let onchain_details = get_onchain_info(&fixed_instructions)?;
+
+            Ok(Payment {
+                payment_methods: vec![PaymentMethod::OnChain(onchain_details.clone().0)],
+                min_amount,
+                max_amount,
+                description: instructions.recipient_description().map(|s| s.to_string()),
+                expected_amount: Some(onchain_details.1),
+                receiving_addr: Some(onchain_details.0.clone()),
+                hrn: instructions.human_readable_name().unwrap().to_string(),
+                notes: "".to_string(),
+            })
+        }
+
+        PaymentInstructions::FixedAmount(instructions) => {
+            let onchain_info = get_onchain_info(instructions)?;
+
+            Ok(Payment {
+                payment_methods: vec![PaymentMethod::OnChain(onchain_info.clone().0)],
+                min_amount: None,
+                max_amount: instructions
+                    .max_amount()
+                    .map(|amnt| Amount::from_sat(amnt.milli_sats())),
+                description: instructions.recipient_description().map(|s| s.to_string()),
+                expected_amount: Some(onchain_info.1),
+                receiving_addr: Some(onchain_info.0),
+                notes: "".to_string(),
+                hrn: instructions.human_readable_name().unwrap().to_string(),
+            })
+        }
+    }
+}
+
+/// Resolves the dns payment instructions found at the specified Human Readable Name
+pub async fn resolve_dns_recipient(
+    hrn: &str,
+    network: Network,
+    ip: String,
+) -> Result<Payment, ParseError> {
+    let (resolver, instructions) = parse_dns_instructions(hrn, network, ip).await?;
+
+    match instructions {
+        PaymentInstructions::ConfigurableAmount(ix) => {
+            let description = ix.recipient_description().map(|s| s.to_string());
+            let min_amount = ix.min_amt().map(|amnt| Amount::from_sat(amnt.milli_sats()));
+            let max_amount = ix.max_amt().map(|amnt| Amount::from_sat(amnt.milli_sats()));
+
+            // Let's set a dummy amount to resolve the payment methods accepted.
+            let fixed_instructions = ix
+                .set_amount(amount::Amount::ZERO, &resolver)
+                .await
+                .map_err(ParseError::InvalidInstructions)?;
+
+            let payment = Payment {
+                min_amount,
+                max_amount,
+                payment_methods: fixed_instructions.methods().into(),
+                description,
+                expected_amount: None,
+                receiving_addr: None,
+                hrn: hrn.to_string(),
+                notes: "This is configurable payment instructions. You must send an amount between min_amount and max_amount if set.".to_string()
+            };
+
+            Ok(payment)
+        }
+
+        PaymentInstructions::FixedAmount(ix) => {
+            let max_amount = ix
+                .max_amount()
+                .map(|amnt| Amount::from_sat(amnt.milli_sats()));
+
+            let payment = Payment {
+                min_amount: None,
+                max_amount,
+                payment_methods: ix.methods().into(),
+                description: ix.recipient_description().map(|s| s.to_string()),
+                expected_amount: None,
+                receiving_addr: None,
+                hrn: hrn.to_string(),
+                notes: "This is a fixed payment instructions. You must send exactly the amount specified in max_amount.".to_string()
+            };
+
+            Ok(payment)
+        }
+    }
+}

--- a/src/dns_payment_instructions.rs
+++ b/src/dns_payment_instructions.rs
@@ -3,115 +3,58 @@ use bitcoin_payment_instructions::{
     FixedAmountPaymentInstructions, ParseError, PaymentInstructions, PaymentMethod,
     PaymentMethodType, amount, dns_resolver::DNSHrnResolver,
 };
-use cli_table::{Cell, Style, Table, format::Justify};
 use core::{net::SocketAddr, str::FromStr};
 
 use crate::{error::BDKCliError as Error, utils::shorten};
 
 #[derive(Debug)]
-pub struct Payment {
+pub struct ResolvedPaymentInfo {
+    pub hrn: String,
     pub payment_methods: Vec<PaymentMethod>,
+    pub description: Option<String>,
     pub min_amount: Option<Amount>,
     pub max_amount: Option<Amount>,
-    pub description: Option<String>,
-    pub expected_amount: Option<Amount>,
-    pub receiving_addr: Option<Address>,
-    pub hrn: String,
     pub notes: String,
 }
 
-impl Payment {
-    pub fn display(&self, pretty: bool) -> Result<String, Error> {
-        let mut methods: Vec<String> = Vec::new();
-        self.payment_methods.iter().for_each(|pm| match pm {
-            bitcoin_payment_instructions::PaymentMethod::LightningBolt11(bolt11) => {
-                methods.push(format!("Bolt 11 invoice ({})", shorten(bolt11, 20, 15)))
-            }
-            bitcoin_payment_instructions::PaymentMethod::LightningBolt12(offer) => {
-                methods.push(format!("Bolt 12 invoice ({})", shorten(offer, 20, 15)))
-            }
-            bitcoin_payment_instructions::PaymentMethod::OnChain(address) => {
-                methods.push(format!("On chain ({})", address))
-            }
-            bitcoin_payment_instructions::PaymentMethod::Cashu(csh) => {
-                methods.push(format!("Cashu payment ({})", shorten(csh, 20, 15)))
-            }
-        });
+impl ResolvedPaymentInfo {
+    pub fn display(&self) -> Result<String, Error> {
+        let methods: Vec<String> = self
+            .payment_methods
+            .iter()
+            .map(|pm| match pm {
+                PaymentMethod::LightningBolt11(bolt11) => {
+                    format!("Bolt 11 invoice ({})", shorten(bolt11, 20, 15))
+                }
+                PaymentMethod::LightningBolt12(offer) => format!("Bolt 12 invoice ({})", offer),
+                PaymentMethod::OnChain(address) => format!("On chain ({})", address),
+                PaymentMethod::Cashu(csh) => format!("Cashu payment ({})", csh),
+            })
+            .collect();
 
-        if pretty {
-            let mut table = vec![vec![
-                "HRN".cell().bold(true),
-                self.hrn.to_string().cell().justify(Justify::Right),
-            ]];
-
-            if let Some(min_amnt) = self.min_amount {
-                table.push(vec![
-                    "Min amount".cell().bold(true),
-                    min_amnt.to_string().cell().justify(Justify::Right),
-                ]);
-            }
-
-            if let Some(max_amnt) = self.max_amount {
-                table.push(vec![
-                    "Max amount".cell().bold(true),
-                    max_amnt.to_string().cell().justify(Justify::Right),
-                ]);
-            }
-
-            if let Some(send_amnt) = self.expected_amount {
-                table.push(vec![
-                    "Expected Amount to send".cell().bold(true),
-                    send_amnt.to_string().cell().justify(Justify::Right),
-                ]);
-            }
-
-            if let Some(descr) = &self.description {
-                table.push(vec![
-                    "Description".cell().bold(true),
-                    descr.cell().justify(Justify::Right),
-                ]);
-            }
-
-            table.push(vec![
-                "Accepted methods".cell().bold(true),
-                methods.join(", ").cell().justify(Justify::Right),
-            ]);
-            table.push(vec![
-                "Notes".cell().bold(true),
-                self.notes.clone().cell().justify(Justify::Right),
-            ]);
-
-            let table = table
-                .table()
-                .display()
-                .map_err(|e| Error::Generic(e.to_string()))?;
-
-            Ok(format!("{table}"))
-        } else {
-            Ok(serde_json::to_string_pretty(&serde_json::json!({
-                    "hrn": self.hrn,
-                    "payment_methods": methods,
-                    "description": self.description,
-                    "min_amount": self.min_amount,
-                    "max_amount": self.max_amount,
-                    "expected_amount_to_send": self.expected_amount,
-                    "notes": self.notes
-            }))?)
-        }
+        Ok(serde_json::to_string_pretty(&serde_json::json!({
+                "hrn": self.hrn,
+                "payment_methods": methods,
+                "description": self.description,
+                "min_amount": self.min_amount,
+                "max_amount": self.max_amount,
+                "notes": self.notes
+        }))?)
     }
 }
+
 pub(crate) async fn parse_dns_instructions(
     hrn: &str,
     network: Network,
-    resolver_ip: String,
+    dns_resolver: &str,
 ) -> Result<(DNSHrnResolver, PaymentInstructions), ParseError> {
-    let ip_address = if resolver_ip.contains(':') {
-        resolver_ip
+    let ip_address = if dns_resolver.contains(':') {
+        dns_resolver
     } else {
-        format!("{resolver_ip}:53")
+        &format!("{dns_resolver}:53")
     };
 
-    let sock_addr = SocketAddr::from_str(&ip_address).map_err(|_| {
+    let sock_addr = SocketAddr::from_str(ip_address).map_err(|_| {
         ParseError::HrnResolutionError("Unable to create socket from provided address")
     })?;
     let resolver = DNSHrnResolver(sock_addr);
@@ -148,7 +91,7 @@ pub async fn process_instructions(
     amount_to_send: Amount,
     payment_instructions: &PaymentInstructions,
     resolver: DNSHrnResolver,
-) -> Result<Payment, Error> {
+) -> Result<(Address, Amount), Error> {
     match payment_instructions {
         PaymentInstructions::ConfigurableAmount(instructions) => {
             // Look for on chain payment method as it's the only one we can support
@@ -200,34 +143,10 @@ pub async fn process_instructions(
 
             let onchain_details = get_onchain_info(&fixed_instructions)?;
 
-            Ok(Payment {
-                payment_methods: vec![PaymentMethod::OnChain(onchain_details.clone().0)],
-                min_amount,
-                max_amount,
-                description: instructions.recipient_description().map(|s| s.to_string()),
-                expected_amount: Some(onchain_details.1),
-                receiving_addr: Some(onchain_details.0.clone()),
-                hrn: instructions.human_readable_name().unwrap().to_string(),
-                notes: "".to_string(),
-            })
+            Ok((onchain_details.0.clone(), onchain_details.1))
         }
 
-        PaymentInstructions::FixedAmount(instructions) => {
-            let onchain_info = get_onchain_info(instructions)?;
-
-            Ok(Payment {
-                payment_methods: vec![PaymentMethod::OnChain(onchain_info.clone().0)],
-                min_amount: None,
-                max_amount: instructions
-                    .max_amount()
-                    .map(|amnt| Amount::from_sat(amnt.milli_sats())),
-                description: instructions.recipient_description().map(|s| s.to_string()),
-                expected_amount: Some(onchain_info.1),
-                receiving_addr: Some(onchain_info.0),
-                notes: "".to_string(),
-                hrn: instructions.human_readable_name().unwrap().to_string(),
-            })
-        }
+        PaymentInstructions::FixedAmount(instructions) => Ok(get_onchain_info(instructions)?),
     }
 }
 
@@ -235,9 +154,9 @@ pub async fn process_instructions(
 pub async fn resolve_dns_recipient(
     hrn: &str,
     network: Network,
-    ip: String,
-) -> Result<Payment, ParseError> {
-    let (resolver, instructions) = parse_dns_instructions(hrn, network, ip).await?;
+    dns_resolver: &str,
+) -> Result<ResolvedPaymentInfo, ParseError> {
+    let (resolver, instructions) = parse_dns_instructions(hrn, network, dns_resolver).await?;
 
     match instructions {
         PaymentInstructions::ConfigurableAmount(ix) => {
@@ -251,15 +170,13 @@ pub async fn resolve_dns_recipient(
                 .await
                 .map_err(ParseError::InvalidInstructions)?;
 
-            let payment = Payment {
+            let payment = ResolvedPaymentInfo {
                 min_amount,
                 max_amount,
                 payment_methods: fixed_instructions.methods().into(),
                 description,
-                expected_amount: None,
-                receiving_addr: None,
                 hrn: hrn.to_string(),
-                notes: "This is configurable payment instructions. You must send an amount between min_amount and max_amount if set.".to_string()
+                notes: "This is configurable payment instructions. You must send an amount between min_amount and max_amount if set.".to_string(),
             };
 
             Ok(payment)
@@ -270,15 +187,13 @@ pub async fn resolve_dns_recipient(
                 .max_amount()
                 .map(|amnt| Amount::from_sat(amnt.milli_sats()));
 
-            let payment = Payment {
+            let payment = ResolvedPaymentInfo {
                 min_amount: None,
                 max_amount,
                 payment_methods: ix.methods().into(),
                 description: ix.recipient_description().map(|s| s.to_string()),
-                expected_amount: None,
-                receiving_addr: None,
                 hrn: hrn.to_string(),
-                notes: "This is a fixed payment instructions. You must send exactly the amount specified in max_amount.".to_string()
+                notes: "This is a fixed payment instructions. You must send exactly the amount specified in max_amount.".to_string(),
             };
 
             Ok(payment)

--- a/src/dns_payment_instructions.rs
+++ b/src/dns_payment_instructions.rs
@@ -4,8 +4,9 @@ use bitcoin_payment_instructions::{
     PaymentMethodType, amount, dns_resolver::DNSHrnResolver,
 };
 use core::{net::SocketAddr, str::FromStr};
+use tokio::time::timeout;
 
-use crate::{error::BDKCliError as Error, utils::shorten};
+use crate::error::BDKCliError as Error;
 
 #[derive(Debug)]
 pub struct ResolvedPaymentInfo {
@@ -24,7 +25,7 @@ impl ResolvedPaymentInfo {
             .iter()
             .map(|pm| match pm {
                 PaymentMethod::LightningBolt11(bolt11) => {
-                    format!("Bolt 11 invoice ({})", shorten(bolt11, 20, 15))
+                    format!("Bolt 11 invoice ({})", bolt11)
                 }
                 PaymentMethod::LightningBolt12(offer) => format!("Bolt 12 invoice ({})", offer),
                 PaymentMethod::OnChain(address) => format!("On chain ({})", address),
@@ -58,7 +59,12 @@ pub(crate) async fn parse_dns_instructions(
         ParseError::HrnResolutionError("Unable to create socket from provided address")
     })?;
     let resolver = DNSHrnResolver(sock_addr);
-    let instructions = PaymentInstructions::parse(hrn, network, &resolver, true).await?;
+    let instructions = timeout(
+        std::time::Duration::from_secs(30),
+        PaymentInstructions::parse(hrn, network, &resolver, true),
+    )
+    .await
+    .map_err(|_| ParseError::HrnResolutionError("Resolution request timed out"))??;
     Ok((resolver, instructions))
 }
 
@@ -104,11 +110,11 @@ pub async fn process_instructions(
 
             let min_amount = instructions
                 .min_amt()
-                .map(|amnt| Amount::from_sat(amnt.milli_sats()));
+                .map(|amnt| Amount::from_sat(amnt.sats_rounding_up()));
 
             let max_amount = instructions
                 .max_amt()
-                .map(|amnt| Amount::from_sat(amnt.milli_sats()));
+                .map(|amnt| Amount::from_sat(amnt.sats_rounding_up()));
 
             if min_amount.is_some_and(|min| amount_to_send < min) {
                 return Err(Error::Generic(

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -13,7 +13,9 @@ use crate::commands::OfflineWalletSubCommand::*;
 use crate::commands::*;
 use crate::config::{WalletConfig, WalletConfigInner};
 #[cfg(feature = "dns_payment")]
-use crate::dns_payment_instructions::resolve_dns_recipient;
+use crate::dns_payment_instructions::{
+    parse_dns_instructions, process_instructions, resolve_dns_recipient,
+};
 use crate::error::BDKCliError as Error;
 #[cfg(any(feature = "sqlite", feature = "redb"))]
 use crate::persister::Persister;
@@ -563,20 +565,14 @@ pub async fn handle_offline_wallet_subcommand(
 
                 #[cfg(feature = "dns_payment")]
                 for recipient in dns_recipients {
-                    use crate::dns_payment_instructions::{
-                        parse_dns_instructions, process_instructions,
-                    };
                     let amount = Amount::from_sat(recipient.1);
-                    let (resolver, instructions) = parse_dns_instructions(
-                        &recipient.0,
-                        cli_opts.network,
-                        dns_resolver.clone(),
-                    )
-                    .await
-                    .map_err(|e| Error::Generic(format!("Parsing error occured {e:#?}")))?;
+                    let (resolver, instructions) =
+                        parse_dns_instructions(&recipient.0, cli_opts.network, &dns_resolver)
+                            .await
+                            .map_err(|e| Error::Generic(format!("Parsing error occured {e:#?}")))?;
                     let payment = process_instructions(amount, &instructions, resolver).await?;
 
-                    recipients.push((payment.receiving_addr.unwrap().into(), amount));
+                    recipients.push((payment.0.into(), payment.1));
                 }
 
                 tx_builder.set_recipients(recipients);
@@ -1396,16 +1392,15 @@ pub(crate) fn handle_compile_subcommand(
 
 #[cfg(feature = "dns_payment")]
 pub(crate) async fn handle_resolve_dns_recipient_command(
-    pretty: bool,
     hrn: &str,
-    resolver: String,
+    resolver: &str,
     network: Network,
 ) -> Result<String, Error> {
     let resolved = resolve_dns_recipient(hrn, network, resolver)
         .await
         .map_err(|e| Error::Generic(format!("{:?}", e)))?;
 
-    resolved.display(pretty)
+    resolved.display()
 }
 
 /// Handle wallets command to show all saved wallet configurations
@@ -1803,13 +1798,8 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
 
         #[cfg(feature = "dns_payment")]
         CliSubCommand::ResolveDnsRecipient { hrn, resolver } => {
-            let res = handle_resolve_dns_recipient_command(
-                cli_opts.pretty,
-                &hrn,
-                resolver,
-                cli_opts.network,
-            )
-            .await?;
+            let res =
+                handle_resolve_dns_recipient_command(&hrn, &resolver, cli_opts.network).await?;
             Ok(res)
         }
     };

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -25,7 +25,6 @@ use crate::utils::*;
 #[cfg(feature = "redb")]
 use bdk_redb::Store as RedbStore;
 use bdk_wallet::bip39::{Language, Mnemonic};
-use bdk_wallet::bitcoin::ScriptBuf;
 use bdk_wallet::bitcoin::base64::Engine;
 use bdk_wallet::bitcoin::base64::prelude::BASE64_STANDARD;
 use bdk_wallet::bitcoin::{
@@ -558,13 +557,14 @@ pub async fn handle_offline_wallet_subcommand(
                 }
             } else {
                 #[allow(unused_mut)]
-                let mut recipients: Vec<(ScriptBuf, Amount)> = recipients
+                let mut recipients: Vec<_> = recipients
                     .into_iter()
                     .map(|(script, amount)| (script, Amount::from_sat(amount)))
                     .collect();
 
                 #[cfg(feature = "dns_payment")]
                 for recipient in dns_recipients {
+                    println!("Resolving DNS instructions for recipient {}", recipient.0);
                     let amount = Amount::from_sat(recipient.1);
                     let (resolver, instructions) =
                         parse_dns_instructions(&recipient.0, cli_opts.network, &dns_resolver)

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -12,6 +12,8 @@
 use crate::commands::OfflineWalletSubCommand::*;
 use crate::commands::*;
 use crate::config::{WalletConfig, WalletConfigInner};
+#[cfg(feature = "dns_payment")]
+use crate::dns_payment_instructions::resolve_dns_recipient;
 use crate::error::BDKCliError as Error;
 #[cfg(any(feature = "sqlite", feature = "redb"))]
 use crate::persister::Persister;
@@ -21,6 +23,7 @@ use crate::utils::*;
 #[cfg(feature = "redb")]
 use bdk_redb::Store as RedbStore;
 use bdk_wallet::bip39::{Language, Mnemonic};
+use bdk_wallet::bitcoin::ScriptBuf;
 use bdk_wallet::bitcoin::base64::Engine;
 use bdk_wallet::bitcoin::base64::prelude::BASE64_STANDARD;
 use bdk_wallet::bitcoin::{
@@ -112,7 +115,7 @@ const NUMS_UNSPENDABLE_KEY_HEX: &str =
 /// Execute an offline wallet sub-command
 ///
 /// Offline wallet sub-commands are described in [`OfflineWalletSubCommand`].
-pub fn handle_offline_wallet_subcommand(
+pub async fn handle_offline_wallet_subcommand(
     wallet: &mut Wallet,
     wallet_opts: &WalletOpts,
     cli_opts: &CliOpts,
@@ -526,6 +529,10 @@ pub fn handle_offline_wallet_subcommand(
         }
         CreateTx {
             recipients,
+            #[cfg(feature = "dns_payment")]
+            dns_recipients,
+            #[cfg(feature = "dns_payment")]
+            dns_resolver,
             send_all,
             enable_rbf,
             offline_signer,
@@ -548,10 +555,30 @@ pub fn handle_offline_wallet_subcommand(
                     ));
                 }
             } else {
-                let recipients = recipients
+                #[allow(unused_mut)]
+                let mut recipients: Vec<(ScriptBuf, Amount)> = recipients
                     .into_iter()
                     .map(|(script, amount)| (script, Amount::from_sat(amount)))
                     .collect();
+
+                #[cfg(feature = "dns_payment")]
+                for recipient in dns_recipients {
+                    use crate::dns_payment_instructions::{
+                        parse_dns_instructions, process_instructions,
+                    };
+                    let amount = Amount::from_sat(recipient.1);
+                    let (resolver, instructions) = parse_dns_instructions(
+                        &recipient.0,
+                        cli_opts.network,
+                        dns_resolver.clone(),
+                    )
+                    .await
+                    .map_err(|e| Error::Generic(format!("Parsing error occured {e:#?}")))?;
+                    let payment = process_instructions(amount, &instructions, resolver).await?;
+
+                    recipients.push((payment.receiving_addr.unwrap().into(), amount));
+                }
+
                 tx_builder.set_recipients(recipients);
             }
 
@@ -1367,6 +1394,20 @@ pub(crate) fn handle_compile_subcommand(
     }
 }
 
+#[cfg(feature = "dns_payment")]
+pub(crate) async fn handle_resolve_dns_recipient_command(
+    pretty: bool,
+    hrn: &str,
+    resolver: String,
+    network: Network,
+) -> Result<String, Error> {
+    let resolved = resolve_dns_recipient(hrn, network, resolver)
+        .await
+        .map_err(|e| Error::Generic(format!("{:?}", e)))?;
+
+    resolved.display(pretty)
+}
+
 /// Handle wallets command to show all saved wallet configurations
 pub fn handle_wallets_subcommand(datadir: &Path, pretty: bool) -> Result<String, Error> {
     let load_config = WalletConfig::load(datadir)?;
@@ -1619,7 +1660,8 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     &wallet_opts,
                     &cli_opts,
                     offline_subcommand.clone(),
-                )?;
+                )
+                .await?;
                 wallet.persist(&mut persister)?;
                 result
             };
@@ -1631,7 +1673,8 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     &wallet_opts,
                     &cli_opts,
                     offline_subcommand.clone(),
-                )?
+                )
+                .await?
             };
             Ok(result)
         }
@@ -1757,6 +1800,18 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
 
             Ok("".to_string())
         }
+
+        #[cfg(feature = "dns_payment")]
+        CliSubCommand::ResolveDnsRecipient { hrn, resolver } => {
+            let res = handle_resolve_dns_recipient_command(
+                cli_opts.pretty,
+                &hrn,
+                resolver,
+                cli_opts.network,
+            )
+            .await?;
+            Ok(res)
+        }
     };
     result
 }
@@ -1803,6 +1858,7 @@ async fn respond(
         } => {
             let value =
                 handle_offline_wallet_subcommand(wallet, wallet_opts, cli_opts, offline_subcommand)
+                    .await
                     .map_err(|e| e.to_string())?;
             Some(value)
         }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -529,14 +529,7 @@ pub async fn handle_offline_wallet_subcommand(
             }
         }
         CreateTx {
-            #[cfg(feature = "dns_payment")]
-            mut recipients,
-            #[cfg(not(feature = "dns_payment"))]
             recipients,
-            #[cfg(feature = "dns_payment")]
-            dns_recipients,
-            #[cfg(feature = "dns_payment")]
-            dns_resolver,
             send_all,
             enable_rbf,
             offline_signer,
@@ -550,7 +543,103 @@ pub async fn handle_offline_wallet_subcommand(
         } => {
             let mut tx_builder = wallet.build_tx();
 
-            #[cfg(feature = "dns_payment")]
+            if send_all {
+                if recipients.len() == 1 {
+                    tx_builder.drain_wallet().drain_to(recipients[0].0.clone());
+                } else {
+                    return Err(Error::Generic(
+                        "Wallet can only be drained to a single output".to_string(),
+                    ));
+                }
+            } else {
+                let recipients: Vec<_> = recipients
+                    .into_iter()
+                    .map(|(script, amount)| (script, Amount::from_sat(amount)))
+                    .collect();
+                tx_builder.set_recipients(recipients);
+            }
+
+            if !enable_rbf {
+                tx_builder.set_exact_sequence(Sequence::MAX);
+            }
+
+            if offline_signer {
+                tx_builder.include_output_redeem_witness_script();
+            }
+
+            if let Some(fee_rate) = fee_rate
+                && let Some(fee_rate) = FeeRate::from_sat_per_vb(fee_rate as u64)
+            {
+                tx_builder.fee_rate(fee_rate);
+            }
+
+            if let Some(utxos) = utxos {
+                tx_builder
+                    .add_utxos(&utxos[..])
+                    .map_err(|_| bdk_wallet::error::CreateTxError::UnknownUtxo)?;
+            }
+
+            if let Some(unspendable) = unspendable {
+                tx_builder.unspendable(unspendable);
+            }
+
+            if let Some(base64_data) = add_data {
+                let op_return_data = BASE64_STANDARD
+                    .decode(base64_data)
+                    .map_err(|e| Error::Generic(e.to_string()))?;
+                tx_builder.add_data(
+                    &PushBytesBuf::try_from(op_return_data)
+                        .map_err(|e| Error::Generic(e.to_string()))?,
+                );
+            } else if let Some(string_data) = add_string {
+                let data = PushBytesBuf::try_from(string_data.as_bytes().to_vec())
+                    .map_err(|e| Error::Generic(e.to_string()))?;
+                tx_builder.add_data(&data);
+            }
+
+            let policies = vec![
+                external_policy.map(|p| (p, KeychainKind::External)),
+                internal_policy.map(|p| (p, KeychainKind::Internal)),
+            ];
+
+            for (policy, keychain) in policies.into_iter().flatten() {
+                let policy = serde_json::from_str::<BTreeMap<String, Vec<usize>>>(&policy)?;
+                tx_builder.policy_path(policy, keychain);
+            }
+
+            let psbt = tx_builder.finish()?;
+
+            let psbt_base64 = BASE64_STANDARD.encode(psbt.serialize());
+
+            if wallet_opts.verbose {
+                Ok(serde_json::to_string_pretty(
+                    &json!({"psbt": psbt_base64, "details": psbt}),
+                )?)
+            } else {
+                Ok(serde_json::to_string_pretty(
+                    &json!({"psbt": psbt_base64 }),
+                )?)
+            }
+        }
+        #[cfg(feature = "dns_payment")]
+        CreateDnsTx {
+            recipients,
+            dns_recipients,
+            dns_resolver,
+            send_all,
+            enable_rbf,
+            offline_signer,
+            utxos,
+            unspendable,
+            fee_rate,
+            external_policy,
+            internal_policy,
+            add_data,
+            add_string,
+        } => {
+            let mut tx_builder = wallet.build_tx();
+            let mut recipients = recipients;
+
             for recipient in dns_recipients {
                 log::info!("Resolving DNS instructions for recipient {}", recipient.0);
                 let amount = Amount::from_sat(recipient.1);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -529,6 +529,9 @@ pub async fn handle_offline_wallet_subcommand(
             }
         }
         CreateTx {
+            #[cfg(feature = "dns_payment")]
+            mut recipients,
+            #[cfg(not(feature = "dns_payment"))]
             recipients,
             #[cfg(feature = "dns_payment")]
             dns_recipients,
@@ -547,6 +550,25 @@ pub async fn handle_offline_wallet_subcommand(
         } => {
             let mut tx_builder = wallet.build_tx();
 
+            #[cfg(feature = "dns_payment")]
+            for recipient in dns_recipients {
+                log::info!("Resolving DNS instructions for recipient {}", recipient.0);
+                let amount = Amount::from_sat(recipient.1);
+                let (resolver, instructions) =
+                    parse_dns_instructions(&recipient.0, cli_opts.network, &dns_resolver)
+                        .await
+                        .map_err(|e| Error::Generic(format!("Parsing error occured {e:#?}")))?;
+                let payment = process_instructions(amount, &instructions, resolver).await?;
+
+                recipients.push((payment.0.into(), payment.1.to_sat()));
+            }
+
+            if recipients.is_empty() {
+                return Err(Error::Generic(
+                    "Either --to or --to_dns parameters must be specified".to_string(),
+                ));
+            }
+
             if send_all {
                 if recipients.len() == 1 {
                     tx_builder.drain_wallet().drain_to(recipients[0].0.clone());
@@ -556,25 +578,10 @@ pub async fn handle_offline_wallet_subcommand(
                     ));
                 }
             } else {
-                #[allow(unused_mut)]
-                let mut recipients: Vec<_> = recipients
+                let recipients: Vec<_> = recipients
                     .into_iter()
                     .map(|(script, amount)| (script, Amount::from_sat(amount)))
                     .collect();
-
-                #[cfg(feature = "dns_payment")]
-                for recipient in dns_recipients {
-                    println!("Resolving DNS instructions for recipient {}", recipient.0);
-                    let amount = Amount::from_sat(recipient.1);
-                    let (resolver, instructions) =
-                        parse_dns_instructions(&recipient.0, cli_opts.network, &dns_resolver)
-                            .await
-                            .map_err(|e| Error::Generic(format!("Parsing error occured {e:#?}")))?;
-                    let payment = process_instructions(amount, &instructions, resolver).await?;
-
-                    recipients.push((payment.0.into(), payment.1));
-                }
-
                 tx_builder.set_recipients(recipients);
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,9 @@ mod payjoin;
 mod persister;
 mod utils;
 
+#[cfg(feature = "dns_payment")]
+mod dns_payment_instructions;
+
 use bdk_wallet::bitcoin::Network;
 use log::{debug, error, warn};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -96,6 +96,17 @@ pub(crate) fn parse_sp_code_value_pairs(s: &str) -> Result<(SilentPaymentCode, u
     Ok((key, value))
 }
 
+#[cfg(feature = "dns_payment")]
+/// Parse dns recipients in the form "test@me.com:10000" from cli input
+pub(crate) fn parse_dns_recipient(s: &str) -> Result<(String, u64), String> {
+    let parts: Vec<_> = s.split(':').collect();
+    if parts.len() != 2 {
+        return Err("Invalid format".to_string());
+    }
+    let sending_amount = u64::from_str(parts[1]).map_err(|e| e.to_string())?;
+    Ok((parts[0].to_string(), sending_amount))
+}
+
 #[cfg(any(feature = "electrum", feature = "esplora", feature = "rpc"))]
 /// Parse the proxy (Socket:Port) argument from the cli input.
 pub(crate) fn parse_proxy_auth(s: &str) -> Result<(String, String), Error> {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds support for BIP353 payment instructions. 
The following notable changes are done: 

- Adding of an option `resolve_dns_recipient` which receives a Human Readable Name (HRN) and returns the associated address
- Modify the `create_tx` for it to support user specifying recipients as `HRN`.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
Here is a list of HRN that could be used to test the implementation: 
- pay@dunxen.dev: Supports BOLT 12 Payment method only (CAUTION: mainnet)
- send.some@satsto.me: Supports BOLT 12 payment and On Chain (CAUTION: mainnet)
- Testing resolving: `bdk-cli -n testnet resolve_dns_recipient testnet@bitdevsyde.org`
- Testing create tx: `bdk-cli -n testnet wallet -w regtest_default_wallet create_tx --to "bcrt1qe497k549sgw9trzym50tdlegq3xx4apjqynjqm:1000" --to_dns "testnet@bitdevsyde.org:5000"`

## Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

- Add top level command `resolve_dns_recipient` to resolve the DNS payment instructions
- Add option `--to_dns` to `create_tx` command to allow sending to a Human Readable Name (HRN)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`
