### PR TITLE
Payjoin persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,16 +120,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -150,9 +144,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -160,24 +154,24 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -218,14 +212,14 @@ dependencies = [
  "env_logger",
  "log",
  "payjoin",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
- "shlex",
+ "shlex 1.3.0",
  "tap",
  "thiserror 2.0.18",
  "tokio",
- "toml 1.1.1+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -380,7 +374,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.15.0",
  "chacha20-poly1305",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -390,24 +384,23 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "serde",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
- "bitcoin-internals 0.3.0",
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.101",
  "bitcoin-units",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
@@ -421,6 +414,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "060c05780195789a7b89bbfe7f57a1a8cd6ae0bb3daa9b96eeca4fbe0ba8014f"
 dependencies = [
  "bitcoin",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -444,24 +446,27 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bitcoin-internals"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90bbbfa552b49101a230fb2668f3f9ef968c81e6f83cf577e1d4b80f689e1aa"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
+name = "bitcoin-internals"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -487,7 +492,7 @@ dependencies = [
  "hkdf 0.11.0",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "sha2 0.9.9",
@@ -497,21 +502,21 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals 0.3.0",
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.101",
  "hex-conservative 0.2.2",
  "serde",
 ]
@@ -562,9 +567,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -586,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -598,20 +609,20 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -736,9 +747,9 @@ checksum = "bba18ee93d577a8428902687bcc2b6b45a56b1981a1f6d779731c86cc4c5db18"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -758,18 +769,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -820,6 +831,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -913,6 +934,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,7 +1033,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -989,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -999,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1056,21 +1109,15 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1229,15 +1276,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1273,18 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1371,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1410,9 +1446,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1430,19 +1466,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
- "rustls-pki-types",
+ "rustls 0.23.41",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -1486,12 +1521,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1499,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1512,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1526,15 +1562,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1546,15 +1582,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1564,12 +1600,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -1584,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1594,14 +1624,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1620,16 +1648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,10 +1661,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1656,11 +1675,60 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
  "quote",
  "syn",
 ]
@@ -1677,13 +1745,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.93"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1706,22 +1773,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1745,9 +1806,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1760,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1772,15 +1833,15 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniscript"
-version = "12.3.5"
+version = "12.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
+checksum = "b8343cc1ef1408bd9bdbf69f7aef47017dfab7e6349ec26fddf62e0e9fb5a4cf"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1803,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1858,15 +1919,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1890,9 +1950,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1931,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "payjoin"
-version = "1.0.0-rc.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e20b76ae28f1420a918e8051681fc9669ed7273e542e515baa329be78c3255a"
+checksum = "844f2404db4ae16c4062a53da2c73812c7a130abf612149c06650a36e34d0a35"
 dependencies = [
  "bhttp",
  "bitcoin",
@@ -1946,6 +2006,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
+ "web-time",
 ]
 
 [[package]]
@@ -1968,9 +2029,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -2014,18 +2075,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2040,12 +2101,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2060,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2070,7 +2143,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -2080,17 +2153,18 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2115,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2136,9 +2210,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2147,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2208,7 +2282,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2224,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2247,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2273,7 +2347,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2289,14 +2363,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2305,13 +2379,19 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2341,7 +2421,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2356,12 +2436,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2382,29 +2471,68 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.41",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2418,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2439,6 +2567,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2471,8 +2608,8 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
- "rand 0.8.5",
+ "bitcoin_hashes 0.14.101",
+ "rand 0.8.6",
  "secp256k1-sys",
  "serde",
 ]
@@ -2492,7 +2629,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2511,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2547,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2619,6 +2756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,6 +2772,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,15 +2795,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2670,9 +2829,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2712,7 +2871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2778,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2803,9 +2962,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2820,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2845,7 +3004,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -2860,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2884,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -2914,20 +3073,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3007,9 +3166,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3031,12 +3190,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -3108,6 +3261,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,27 +3287,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.116"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3155,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.66"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3165,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.116"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3175,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.116"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3188,52 +3342,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.116"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.93"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3250,6 +3370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,9 +3386,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3459,109 +3588,27 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3570,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3582,18 +3629,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3602,18 +3649,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3623,18 +3670,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3643,9 +3690,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3654,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3665,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ esplora = ["bdk_esplora", "_payjoin-dependencies"]
 rpc = ["bdk_bitcoind_rpc", "_payjoin-dependencies"] 
 
 # Internal features
-_payjoin-dependencies = ["payjoin", "reqwest", "url"]
+_payjoin-dependencies = ["payjoin", "reqwest", "url", "sqlite"]
 bip322 = ["bdk_bip322"]
 
 # Use this to consensus verify transactions at sync time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ bdk_esplora = { version = "0.22.2", features = ["async-https", "tokio"], optiona
 bdk_kyoto = { version = "0.15.4", optional = true }
 bdk_redb = { version = "0.1.1", optional = true }
 bdk_sp = { version = "0.1.0", optional = true, git = "https://github.com/bitcoindevkit/bdk-sp", tag = "v0.1.0" }
-payjoin = { version = "=1.0.0-rc.1", features = ["v1", "v2", "io", "_test-utils"], optional = true}
-reqwest = { version = "0.13.2", default-features = false, optional = true }
+payjoin = { version = "0.25.0", features = ["v1", "v2", "io", "_test-utils"], optional = true}
+reqwest = { version = "0.13.2", default-features = false, features = ["rustls"], optional = true }
 url = { version = "2.5.8", optional = true }
 bdk_bip322 = { version = "0.1.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And yes, it can do Taproot!!
 This crate can be used for the following purposes:
  - Instantly create a miniscript based wallet and connect to your backend of choice (Electrum, Esplora, Core RPC, Kyoto etc) and quickly play around with your own complex bitcoin scripting workflow. With one or many wallets, connected with one or many backends.
  - The `tests/integration.rs` module is used to document high level complex workflows between BDK and different Bitcoin infrastructure systems, like Core, Electrum and Lightning(soon TM).
- - Receive and send Async Payjoins. Note that even though Async Payjoin as a protocol allows the receiver and sender to go offline during the payjoin, the BDK CLI implementation currently does not support persisting.
+ - Receive and send Async Payjoins with session persistence. Sessions can be resumed if interrupted.
  - (Planned) Expose the basic command handler via `wasm` to integrate `bdk-cli` functionality natively into the web platform. See also the [playground](https://bitcoindevkit.org/bdk-cli/playground/) page.
 
 If you are considering using BDK in your own wallet project bdk-cli is a nice playground to get started with. It allows easy testnet and regtest wallet operations, to try out what's possible with descriptors, miniscript, and BDK APIs. For more information on BDK refer to the [website](https://bitcoindevkit.org/) and the [rust docs](https://docs.rs/bdk_wallet/1.0.0/bdk_wallet/index.html)
@@ -173,6 +173,33 @@ cargo run --features electrum,sp -- --network testnet4 wallet --wallet sample_wa
 It's also possible to drain all balance to a silent payment wallet by using the `--send_all` flag:
 ```shell
 cargo run --features electrum,sp -- --network testnet4 wallet --wallet sample_wallet --ext-descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" --database-type sqlite --client-type electrum --url "ssl://mempool.space:40002" create_sp_tx --send_all --to-sp <SP_CODE_1>:0
+```
+
+### Payjoin
+
+#### Payjoin Session Persistence
+
+Payjoin sessions are automatically persisted to a SQLite database (`payjoin.sqlite`) in the data directory. This allows sessions to be resumed if interrupted. Old completed sessions and stale inactive sessions older than 30 days are pruned automatically when the payjoin database is accessed.
+
+##### Resume Payjoin Sessions
+
+Resume all pending sessions:
+```
+cargo run --features rpc -- wallet --wallet <wallet_name> resume_payjoin --directory "https://payjo.in" --ohttp_relay "https://pj.bobspacebkk.com"
+```
+
+Resume a specific session by ID:
+```
+cargo run --features rpc -- wallet --wallet <wallet_name> resume_payjoin --directory "https://payjo.in" --ohttp_relay "https://pj.bobspacebkk.com" --session_id <id>
+```
+
+Sessions are processed sequentially (not concurrently) due to BDK-CLI's architecture. Each session waits up to 30 seconds for updates before timing out. If no session ID is specified, the most recent active sessions are resumed first.
+
+##### View Session History
+
+View all payjoin sessions (active and completed) and also see their status:
+```
+cargo run -- wallet --wallet <wallet_name> payjoin_history
 ```
 
 ## Justfile

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -636,6 +636,20 @@ pub enum OnlineWalletSubCommand {
         )]
         fee_rate: u64,
     },
+    /// Resume pending payjoin sessions.
+    ResumePayjoin {
+        /// Payjoin directory for the session
+        #[arg(env = "PAYJOIN_DIRECTORY", long = "directory", required = true)]
+        directory: String,
+        /// URL of the Payjoin OHTTP relay. Can be repeated multiple times.
+        #[arg(env = "PAYJOIN_OHTTP_RELAY", long = "ohttp_relay", required = true)]
+        ohttp_relay: Vec<String>,
+        /// Resume only a specific active session ID (sender and/or receiver).
+        #[arg(env = "PAYJOIN_SESSION_ID", long = "session_id")]
+        session_id: Option<i64>,
+    },
+    /// Show payjoin session history.
+    PayjoinHistory,
 }
 
 /// Subcommands for Key operations.

--- a/src/error.rs
+++ b/src/error.rs
@@ -152,6 +152,10 @@ pub enum BDKCliError {
     #[error("Payjoin create request error: {0}")]
     PayjoinCreateRequest(#[from] payjoin::send::v2::CreateRequestError),
 
+    #[cfg(feature = "payjoin")]
+    #[error("Payjoin database error: {0}")]
+    PayjoinDb(#[from] crate::payjoin::db::Error),
+
     #[cfg(feature = "bip322")]
     #[error("BIP-322 error: {0}")]
     Bip322Error(#[from] bdk_bip322::error::Error),
@@ -181,5 +185,18 @@ impl From<bdk_redb::redb::DatabaseError> for BDKCliError {
 impl From<bdk_wallet::rusqlite::Error> for BDKCliError {
     fn from(err: bdk_wallet::rusqlite::Error) -> Self {
         BDKCliError::RusqliteError(Box::new(err))
+    }
+}
+
+#[cfg(feature = "payjoin")]
+impl<ApiErr, StorageErr, ErrorState>
+    From<payjoin::persist::PersistedError<ApiErr, StorageErr, ErrorState>> for BDKCliError
+where
+    ApiErr: std::error::Error,
+    StorageErr: std::error::Error,
+    ErrorState: std::fmt::Debug,
+{
+    fn from(e: payjoin::persist::PersistedError<ApiErr, StorageErr, ErrorState>) -> Self {
+        BDKCliError::Generic(e.to_string())
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -77,14 +77,7 @@ use std::convert::TryFrom;
 use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
-#[cfg(any(
-    feature = "redb",
-    feature = "compiler",
-    feature = "electrum",
-    feature = "esplora",
-    feature = "cbf",
-    feature = "rpc"
-))]
+#[cfg(any(feature = "redb", feature = "compiler"))]
 use std::sync::Arc;
 
 #[cfg(feature = "bip322")]
@@ -100,9 +93,8 @@ use bdk_bip322::{BIP322, MessageProof, MessageVerificationResult};
 ))]
 use {
     crate::commands::OnlineWalletSubCommand::*,
-    crate::payjoin::{PayjoinManager, ohttp::RelayManager},
+    crate::payjoin::PayjoinManager,
     bdk_wallet::bitcoin::{Transaction, consensus::Decodable, hex::FromHex},
-    std::sync::Mutex,
 };
 #[cfg(feature = "esplora")]
 use {crate::utils::BlockchainClient::Esplora, bdk_esplora::EsploraAsyncExt};
@@ -863,6 +855,8 @@ pub(crate) async fn handle_online_wallet_subcommand(
     wallet: &mut Wallet,
     client: &BlockchainClient,
     online_subcommand: OnlineWalletSubCommand,
+    datadir: Option<std::path::PathBuf>,
+    wallet_name: &str,
 ) -> Result<String, Error> {
     match online_subcommand {
         FullScan {
@@ -989,8 +983,7 @@ pub(crate) async fn handle_online_wallet_subcommand(
             ohttp_relay,
             max_fee_rate,
         } => {
-            let relay_manager = Arc::new(Mutex::new(RelayManager::new()));
-            let mut payjoin_manager = PayjoinManager::new(wallet, relay_manager);
+            let mut payjoin_manager = PayjoinManager::new(wallet, datadir.clone(), wallet_name)?;
             return payjoin_manager
                 .receive_payjoin(amount, directory, max_fee_rate, ohttp_relay, client)
                 .await;
@@ -1000,12 +993,22 @@ pub(crate) async fn handle_online_wallet_subcommand(
             ohttp_relay,
             fee_rate,
         } => {
-            let relay_manager = Arc::new(Mutex::new(RelayManager::new()));
-            let mut payjoin_manager = PayjoinManager::new(wallet, relay_manager);
+            let mut payjoin_manager = PayjoinManager::new(wallet, datadir.clone(), wallet_name)?;
             return payjoin_manager
                 .send_payjoin(uri, fee_rate, ohttp_relay, client)
                 .await;
         }
+        ResumePayjoin {
+            directory,
+            ohttp_relay,
+            session_id,
+        } => {
+            let mut payjoin_manager = PayjoinManager::new(wallet, datadir, wallet_name)?;
+            return payjoin_manager
+                .resume_payjoins(directory, ohttp_relay, session_id, client)
+                .await;
+        }
+        PayjoinHistory => crate::payjoin::PayjoinManager::history(datadir, wallet_name),
     }
 }
 
@@ -1511,14 +1514,14 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
             feature = "rpc"
         ))]
         CliSubCommand::Wallet {
-            wallet,
+            wallet: wallet_name,
             subcommand: WalletSubCommand::OnlineWalletSubCommand(online_subcommand),
         } => {
-            let home_dir = prepare_home_dir(cli_opts.datadir)?;
+            let home_dir = prepare_home_dir(cli_opts.datadir.clone())?;
 
-            let (wallet_opts, network) = load_wallet_config(&home_dir, &wallet)?;
+            let (wallet_opts, network) = load_wallet_config(&home_dir, &wallet_name)?;
 
-            let database_path = prepare_wallet_db_dir(&home_dir, &wallet)?;
+            let database_path = prepare_wallet_db_dir(&home_dir, &wallet_name)?;
 
             #[cfg(any(feature = "sqlite", feature = "redb"))]
             let result = {
@@ -1532,13 +1535,16 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     }
                     #[cfg(feature = "redb")]
                     DatabaseType::Redb => {
-                        let wallet_name = &wallet_opts.wallet;
+                        let redb_store_wallet_name = &wallet_opts.wallet;
                         let db = Arc::new(bdk_redb::redb::Database::create(
                             home_dir.join("wallet.redb"),
                         )?);
                         let store = RedbStore::new(
                             db,
-                            wallet_name.as_deref().unwrap_or("wallet").to_string(),
+                            redb_store_wallet_name
+                                .as_deref()
+                                .unwrap_or("wallet")
+                                .to_string(),
                         )?;
                         log::debug!("Redb database opened successfully");
                         Persister::RedbStore(store)
@@ -1553,6 +1559,8 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     &mut wallet,
                     &blockchain_client,
                     online_subcommand,
+                    cli_opts.datadir.clone(),
+                    &wallet_name,
                 )
                 .await?;
                 wallet.persist(&mut persister)?;
@@ -1563,8 +1571,14 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                 let mut wallet = new_wallet(network, wallet_opts)?;
                 let blockchain_client =
                     crate::utils::new_blockchain_client(wallet_opts, &wallet, database_path)?;
-                handle_online_wallet_subcommand(&mut wallet, &blockchain_client, online_subcommand)
-                    .await?
+                handle_online_wallet_subcommand(
+                    &mut wallet,
+                    &blockchain_client,
+                    online_subcommand,
+                    cli_opts.datadir.clone(),
+                    &wallet_name,
+                )
+                .await?
             };
             Ok(result)
         }
@@ -1751,7 +1765,7 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
 async fn respond(
     network: Network,
     wallet: &mut Wallet,
-    wallet_name: &String,
+    wallet_name: &str,
     wallet_opts: &mut WalletOpts,
     line: &str,
     _datadir: std::path::PathBuf,
@@ -1773,9 +1787,15 @@ async fn respond(
         } => {
             let blockchain =
                 new_blockchain_client(wallet_opts, wallet, _datadir).map_err(|e| e.to_string())?;
-            let value = handle_online_wallet_subcommand(wallet, &blockchain, online_subcommand)
-                .await
-                .map_err(|e| e.to_string())?;
+            let value = handle_online_wallet_subcommand(
+                wallet,
+                &blockchain,
+                online_subcommand,
+                cli_opts.datadir.clone(),
+                wallet_name,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
             Some(value)
         }
         ReplSubCommand::Wallet {

--- a/src/payjoin/db.rs
+++ b/src/payjoin/db.rs
@@ -527,3 +527,309 @@ impl SessionPersister for ReceiverPersister {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use payjoin::HpkeKeyPair;
+    use payjoin::persist::SessionPersister as _;
+    use payjoin::receive::v2::SessionOutcome as ReceiverSessionOutcome;
+    use payjoin::send::v2::SessionOutcome as SenderSessionOutcome;
+
+    use super::*;
+
+    fn sample_receiver_pubkey() -> HpkePublicKey {
+        HpkeKeyPair::gen_keypair().1
+    }
+
+    fn unique_test_datadir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "bdk-cli-payjoin-{label}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn insert_input_seen_before_reports_replays() {
+        let db = Database::create(":memory:").expect("in-memory database should open");
+        let input = OutPoint::null();
+
+        assert!(
+            !db.insert_input_seen_before(input)
+                .expect("first insert should succeed"),
+            "first observation should not be treated as a replay"
+        );
+        assert!(
+            db.insert_input_seen_before(input)
+                .expect("second insert should succeed"),
+            "second observation should be treated as a replay"
+        );
+    }
+
+    #[test]
+    fn persisters_round_trip_events_and_transition_sessions() {
+        let db = Arc::new(Database::create(":memory:").expect("in-memory database should open"));
+
+        let sender = SenderPersister::new(db.clone(), sample_receiver_pubkey())
+            .expect("sender session should be created");
+        sender
+            .save_event(SenderSessionEvent::PostedOriginalPsbt())
+            .expect("sender event should persist");
+        sender
+            .save_event(SenderSessionEvent::Closed(SenderSessionOutcome::Failure))
+            .expect("sender close event should persist");
+
+        let sender_events: Vec<_> = sender.load().expect("sender events should load").collect();
+        assert_eq!(
+            sender_events,
+            vec![
+                SenderSessionEvent::PostedOriginalPsbt(),
+                SenderSessionEvent::Closed(SenderSessionOutcome::Failure),
+            ]
+        );
+
+        let active_sender_ids = db
+            .get_send_session_ids()
+            .expect("active sender ids should load");
+        assert_eq!(active_sender_ids.len(), 1);
+        assert_eq!(
+            db.get_send_session_receiver_pk(&active_sender_ids[0])
+                .expect("receiver pubkey should load")
+                .to_compressed_bytes()
+                .len(),
+            33
+        );
+
+        sender.close().expect("sender session should close");
+        assert!(
+            db.get_send_session_ids()
+                .expect("active sender ids should load")
+                .is_empty()
+        );
+        assert_eq!(
+            db.get_inactive_send_session_ids()
+                .expect("inactive sender ids should load")
+                .len(),
+            1
+        );
+
+        let receiver =
+            ReceiverPersister::new(db.clone()).expect("receiver session should be created");
+        receiver
+            .save_event(ReceiverSessionEvent::CheckedBroadcastSuitability())
+            .expect("receiver event should persist");
+        receiver
+            .save_event(ReceiverSessionEvent::Closed(ReceiverSessionOutcome::Cancel))
+            .expect("receiver close event should persist");
+
+        let receiver_events: Vec<_> = receiver
+            .load()
+            .expect("receiver events should load")
+            .collect();
+        assert_eq!(
+            receiver_events,
+            vec![
+                ReceiverSessionEvent::CheckedBroadcastSuitability(),
+                ReceiverSessionEvent::Closed(ReceiverSessionOutcome::Cancel),
+            ]
+        );
+
+        receiver.close().expect("receiver session should close");
+        assert!(
+            db.get_recv_session_ids()
+                .expect("active receiver ids should load")
+                .is_empty()
+        );
+        assert_eq!(
+            db.get_inactive_recv_session_ids()
+                .expect("inactive receiver ids should load")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn prune_expired_sessions_drops_stale_send_and_receive_rows() {
+        let db = Database::create(":memory:").expect("in-memory database should open");
+        let stale_timestamp = now() - SESSION_RETENTION_SECS - 1;
+        let fresh_timestamp = now();
+        let receiver_pubkey = sample_receiver_pubkey();
+
+        db.conn()
+            .execute(
+                "INSERT INTO send_sessions (session_id, receiver_pubkey, completed_at)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    1_i64,
+                    receiver_pubkey.to_compressed_bytes(),
+                    stale_timestamp
+                ],
+            )
+            .expect("stale completed send session should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO send_sessions (session_id, receiver_pubkey, completed_at)
+                 VALUES (?1, ?2, NULL)",
+                params![2_i64, receiver_pubkey.to_compressed_bytes()],
+            )
+            .expect("stale active send session should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO send_session_events (session_id, event_data, created_at)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    2_i64,
+                    serde_json::to_string(&SenderSessionEvent::PostedOriginalPsbt())
+                        .expect("event should serialize"),
+                    stale_timestamp
+                ],
+            )
+            .expect("stale send event should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO send_sessions (session_id, receiver_pubkey, completed_at)
+                 VALUES (?1, ?2, NULL)",
+                params![3_i64, receiver_pubkey.to_compressed_bytes()],
+            )
+            .expect("fresh active send session should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO send_session_events (session_id, event_data, created_at)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    3_i64,
+                    serde_json::to_string(&SenderSessionEvent::PostedOriginalPsbt())
+                        .expect("event should serialize"),
+                    fresh_timestamp
+                ],
+            )
+            .expect("fresh send event should insert");
+
+        db.conn()
+            .execute(
+                "INSERT INTO receive_sessions (session_id, completed_at) VALUES (?1, ?2)",
+                params![4_i64, stale_timestamp],
+            )
+            .expect("stale completed receive session should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO receive_sessions (session_id, completed_at) VALUES (?1, NULL)",
+                params![5_i64],
+            )
+            .expect("stale active receive session should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO receive_session_events (session_id, event_data, created_at)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    5_i64,
+                    serde_json::to_string(&ReceiverSessionEvent::CheckedBroadcastSuitability())
+                        .expect("event should serialize"),
+                    stale_timestamp
+                ],
+            )
+            .expect("stale receive event should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO receive_sessions (session_id, completed_at) VALUES (?1, NULL)",
+                params![6_i64],
+            )
+            .expect("fresh active receive session should insert");
+        db.conn()
+            .execute(
+                "INSERT INTO receive_session_events (session_id, event_data, created_at)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    6_i64,
+                    serde_json::to_string(&ReceiverSessionEvent::CheckedBroadcastSuitability())
+                        .expect("event should serialize"),
+                    fresh_timestamp
+                ],
+            )
+            .expect("fresh receive event should insert");
+
+        db.prune_expired_sessions().expect("pruning should succeed");
+
+        let remaining_send_ids: Vec<i64> = db
+            .conn()
+            .prepare("SELECT session_id FROM send_sessions ORDER BY session_id")
+            .expect("statement should prepare")
+            .query_map([], |row| row.get(0))
+            .expect("query should execute")
+            .map(|row| row.expect("row should decode"))
+            .collect();
+        assert_eq!(remaining_send_ids, vec![3]);
+
+        let remaining_receive_ids: Vec<i64> = db
+            .conn()
+            .prepare("SELECT session_id FROM receive_sessions ORDER BY session_id")
+            .expect("statement should prepare")
+            .query_map([], |row| row.get(0))
+            .expect("query should execute")
+            .map(|row| row.expect("row should decode"))
+            .collect();
+        assert_eq!(remaining_receive_ids, vec![6]);
+    }
+
+    #[test]
+    fn history_lists_active_and_completed_sessions() {
+        let datadir = unique_test_datadir("history");
+        let wallet_name = "history-wallet";
+        let db = open_payjoin_db(Some(datadir.clone()), wallet_name)
+            .expect("database should open in temp directory");
+
+        let active_sender = SenderPersister::new(db.clone(), sample_receiver_pubkey())
+            .expect("active sender should be created");
+        let active_receiver =
+            ReceiverPersister::new(db.clone()).expect("active receiver should be created");
+
+        let completed_sender = SenderPersister::new(db.clone(), sample_receiver_pubkey())
+            .expect("completed sender should be created");
+        completed_sender
+            .close()
+            .expect("completed sender should close");
+
+        let completed_receiver =
+            ReceiverPersister::new(db.clone()).expect("completed receiver should be created");
+        completed_receiver
+            .close()
+            .expect("completed receiver should close");
+
+        let active_send_ids = db
+            .get_send_session_ids()
+            .expect("active sender ids should load");
+        let active_recv_ids = db
+            .get_recv_session_ids()
+            .expect("active receiver ids should load");
+        let inactive_send_ids = db
+            .get_inactive_send_session_ids()
+            .expect("inactive sender ids should load");
+        let inactive_recv_ids = db
+            .get_inactive_recv_session_ids()
+            .expect("inactive receiver ids should load");
+
+        let table = crate::payjoin::PayjoinManager::history(Some(datadir.clone()), wallet_name)
+            .expect("history should render");
+
+        assert!(table.contains("Sender"));
+        assert!(table.contains("Receiver"));
+        assert!(table.contains(&active_send_ids[0].to_string()));
+        assert!(table.contains(&active_recv_ids[0].to_string()));
+        assert!(table.contains(&inactive_send_ids[0].0.to_string()));
+        assert!(table.contains(&inactive_recv_ids[0].0.to_string()));
+        assert!(table.contains("Not Completed"));
+
+        drop(active_sender);
+        drop(active_receiver);
+        drop(completed_sender);
+        drop(completed_receiver);
+        drop(db);
+        let _ = std::fs::remove_dir_all(datadir);
+    }
+}

--- a/src/payjoin/db.rs
+++ b/src/payjoin/db.rs
@@ -60,6 +60,7 @@ impl From<Error> for payjoin::ImplementationError {
 
 /// Default filename for the payjoin database
 pub const DB_FILENAME: &str = "payjoin.sqlite";
+const SESSION_RETENTION_SECS: i64 = 30 * 24 * 60 * 60;
 
 pub fn open_payjoin_db(
     datadir: Option<PathBuf>,
@@ -67,7 +68,9 @@ pub fn open_payjoin_db(
 ) -> std::result::Result<Arc<Database>, BDKCliError> {
     let wallet_dir = prepare_home_dir(datadir)?.join(wallet_name);
     std::fs::create_dir_all(&wallet_dir).map_err(|e| BDKCliError::Generic(e.to_string()))?;
-    Ok(Arc::new(Database::create(wallet_dir.join(DB_FILENAME))?))
+    let db = Arc::new(Database::create(wallet_dir.join(DB_FILENAME))?);
+    db.prune_expired_sessions()?;
+    Ok(db)
 }
 
 /// Returns the current Unix timestamp in seconds
@@ -160,6 +163,83 @@ impl Database {
             params![key, now()],
         )? == 0;
         Ok(was_seen_before)
+    }
+
+    /// Removes old completed sessions and stale incomplete sessions plus their event logs.
+    pub fn prune_expired_sessions(&self) -> Result<()> {
+        let cutoff = now() - SESSION_RETENTION_SECS;
+        let mut conn = self.conn();
+        let tx = conn.transaction()?;
+        let stale_send_session_ids = {
+            let mut stmt = tx.prepare(
+                "SELECT session_id FROM send_sessions
+                 WHERE (completed_at IS NOT NULL AND completed_at < ?1)
+                    OR (
+                        completed_at IS NULL
+                        AND session_id IN (
+                            SELECT session_id FROM send_session_events
+                            GROUP BY session_id
+                            HAVING MAX(created_at) < ?1
+                        )
+                    )",
+            )?;
+            let rows = stmt.query_map(params![cutoff], |row| row.get::<_, i64>(0))?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row?);
+            }
+            ids
+        };
+        let stale_receive_session_ids = {
+            let mut stmt = tx.prepare(
+                "SELECT session_id FROM receive_sessions
+                 WHERE (completed_at IS NOT NULL AND completed_at < ?1)
+                    OR (
+                        completed_at IS NULL
+                        AND session_id IN (
+                            SELECT session_id FROM receive_session_events
+                            GROUP BY session_id
+                            HAVING MAX(created_at) < ?1
+                        )
+                    )",
+            )?;
+            let rows = stmt.query_map(params![cutoff], |row| row.get::<_, i64>(0))?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row?);
+            }
+            ids
+        };
+        let deleted_any =
+            !stale_send_session_ids.is_empty() || !stale_receive_session_ids.is_empty();
+
+        for session_id in stale_send_session_ids {
+            tx.execute(
+                "DELETE FROM send_session_events WHERE session_id = ?1",
+                params![session_id],
+            )?;
+            tx.execute(
+                "DELETE FROM send_sessions WHERE session_id = ?1",
+                params![session_id],
+            )?;
+        }
+
+        for session_id in stale_receive_session_ids {
+            tx.execute(
+                "DELETE FROM receive_session_events WHERE session_id = ?1",
+                params![session_id],
+            )?;
+            tx.execute(
+                "DELETE FROM receive_sessions WHERE session_id = ?1",
+                params![session_id],
+            )?;
+        }
+
+        tx.commit()?;
+        if deleted_any {
+            conn.execute("VACUUM", [])?;
+        }
+        Ok(())
     }
 
     /// Returns IDs of all active (incomplete) receive sessions

--- a/src/payjoin/db.rs
+++ b/src/payjoin/db.rs
@@ -1,0 +1,449 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use bdk_wallet::rusqlite::{Connection, ToSql, params, types::ToSqlOutput};
+use payjoin::HpkePublicKey;
+use payjoin::bitcoin::OutPoint;
+use payjoin::bitcoin::consensus::encode::serialize;
+use payjoin::persist::SessionPersister;
+use payjoin::receive::v2::SessionEvent as ReceiverSessionEvent;
+use payjoin::send::v2::SessionEvent as SenderSessionEvent;
+
+use crate::error::BDKCliError;
+use crate::utils::prepare_home_dir;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error type for payjoin database operations
+#[derive(Debug)]
+pub enum Error {
+    /// SQLite database error
+    Rusqlite(bdk_wallet::rusqlite::Error),
+    /// JSON serialization error
+    Serialize(serde_json::Error),
+    /// JSON deserialization error
+    Deserialize(serde_json::Error),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Rusqlite(e) => write!(f, "Database operation failed: {e}"),
+            Error::Serialize(e) => write!(f, "Serialization failed: {e}"),
+            Error::Deserialize(e) => write!(f, "Deserialization failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Rusqlite(e) => Some(e),
+            Error::Serialize(e) => Some(e),
+            Error::Deserialize(e) => Some(e),
+        }
+    }
+}
+
+impl From<bdk_wallet::rusqlite::Error> for Error {
+    fn from(error: bdk_wallet::rusqlite::Error) -> Self {
+        Error::Rusqlite(error)
+    }
+}
+
+impl From<Error> for payjoin::ImplementationError {
+    fn from(error: Error) -> Self {
+        payjoin::ImplementationError::new(error)
+    }
+}
+
+/// Default filename for the payjoin database
+pub const DB_FILENAME: &str = "payjoin.sqlite";
+
+pub fn open_payjoin_db(
+    datadir: Option<PathBuf>,
+    wallet_name: &str,
+) -> std::result::Result<Arc<Database>, BDKCliError> {
+    let wallet_dir = prepare_home_dir(datadir)?.join(wallet_name);
+    std::fs::create_dir_all(&wallet_dir).map_err(|e| BDKCliError::Generic(e.to_string()))?;
+    Ok(Arc::new(Database::create(wallet_dir.join(DB_FILENAME))?))
+}
+
+/// Returns the current Unix timestamp in seconds
+#[inline]
+fn now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+pub struct Database {
+    conn: Mutex<Connection>,
+}
+
+impl Database {
+    pub fn create(path: impl AsRef<Path>) -> Result<Self> {
+        let conn = Connection::open(path.as_ref())?;
+        Self::init_schema(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.conn
+            .lock()
+            .expect("Database mutex should not be poisoned")
+    }
+
+    fn init_schema(conn: &Connection) -> Result<()> {
+        conn.execute("PRAGMA foreign_keys = ON", [])?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS send_sessions (
+                session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                receiver_pubkey BLOB NOT NULL,
+                completed_at INTEGER
+            )",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS receive_sessions (
+                session_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                completed_at INTEGER
+            )",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS send_session_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER NOT NULL,
+                event_data TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY(session_id) REFERENCES send_sessions(session_id)
+            )",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS receive_session_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER NOT NULL,
+                event_data TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                FOREIGN KEY(session_id) REFERENCES receive_sessions(session_id)
+            )",
+            [],
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS inputs_seen (
+                outpoint BLOB PRIMARY KEY,
+                created_at INTEGER NOT NULL
+            )",
+            [],
+        )?;
+
+        Ok(())
+    }
+
+    /// Inserts the input and returns true if the input was seen before, false otherwise.
+    /// This is used for replay protection to prevent probing attacks.
+    pub fn insert_input_seen_before(&self, input: OutPoint) -> Result<bool> {
+        let key = serialize(&input);
+        let was_seen_before = self.conn().execute(
+            "INSERT OR IGNORE INTO inputs_seen (outpoint, created_at) VALUES (?1, ?2)",
+            params![key, now()],
+        )? == 0;
+        Ok(was_seen_before)
+    }
+
+    /// Returns IDs of all active (incomplete) receive sessions
+    pub fn get_recv_session_ids(&self) -> Result<Vec<SessionId>> {
+        let conn = self.conn();
+        let mut stmt =
+            conn.prepare("SELECT session_id FROM receive_sessions WHERE completed_at IS NULL ORDER BY session_id DESC")?;
+
+        let session_rows = stmt.query_map([], |row| {
+            let session_id: i64 = row.get(0)?;
+            Ok(SessionId(session_id))
+        })?;
+
+        let mut session_ids = Vec::new();
+        for session_row in session_rows {
+            session_ids.push(session_row?);
+        }
+
+        Ok(session_ids)
+    }
+
+    /// Returns IDs of all active (incomplete) send sessions
+    pub fn get_send_session_ids(&self) -> Result<Vec<SessionId>> {
+        let conn = self.conn();
+        let mut stmt =
+            conn.prepare("SELECT session_id FROM send_sessions WHERE completed_at IS NULL ORDER BY session_id DESC")?;
+
+        let session_rows = stmt.query_map([], |row| {
+            let session_id: i64 = row.get(0)?;
+            Ok(SessionId(session_id))
+        })?;
+
+        let mut session_ids = Vec::new();
+        for session_row in session_rows {
+            session_ids.push(session_row?);
+        }
+
+        Ok(session_ids)
+    }
+
+    /// Returns the receiver public key for a send session
+    pub fn get_send_session_receiver_pk(&self, session_id: &SessionId) -> Result<HpkePublicKey> {
+        let conn = self.conn();
+        let mut stmt =
+            conn.prepare("SELECT receiver_pubkey FROM send_sessions WHERE session_id = ?1")?;
+        let receiver_pubkey: Vec<u8> = stmt.query_row(params![session_id], |row| row.get(0))?;
+        Ok(HpkePublicKey::from_compressed_bytes(&receiver_pubkey).expect("Valid receiver pubkey"))
+    }
+
+    /// Returns IDs and completion timestamps of all completed send sessions
+    pub fn get_inactive_send_session_ids(&self) -> Result<Vec<(SessionId, u64)>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT session_id, completed_at FROM send_sessions WHERE completed_at IS NOT NULL",
+        )?;
+        let session_rows = stmt.query_map([], |row| {
+            let session_id: i64 = row.get(0)?;
+            let completed_at: u64 = row.get(1)?;
+            Ok((SessionId(session_id), completed_at))
+        })?;
+
+        let mut session_ids = Vec::new();
+        for session_row in session_rows {
+            session_ids.push(session_row?);
+        }
+        Ok(session_ids)
+    }
+
+    /// Returns IDs and completion timestamps of all completed receive sessions
+    pub fn get_inactive_recv_session_ids(&self) -> Result<Vec<(SessionId, u64)>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT session_id, completed_at FROM receive_sessions WHERE completed_at IS NOT NULL",
+        )?;
+        let session_rows = stmt.query_map([], |row| {
+            let session_id: i64 = row.get(0)?;
+            let completed_at: u64 = row.get(1)?;
+            Ok((SessionId(session_id), completed_at))
+        })?;
+
+        let mut session_ids = Vec::new();
+        for session_row in session_rows {
+            session_ids.push(session_row?);
+        }
+        Ok(session_ids)
+    }
+
+    /// Formats a Unix timestamp into local date time text.
+    pub fn format_unix_timestamp(&self, timestamp: u64) -> Result<String> {
+        let Ok(timestamp) = i64::try_from(timestamp) else {
+            return Ok(format!("Invalid timestamp ({timestamp})"));
+        };
+        let conn = self.conn();
+        let dt: Option<String> = conn.query_row(
+            "SELECT datetime(?1, 'unixepoch', 'localtime')",
+            params![timestamp],
+            |row| row.get(0),
+        )?;
+        Ok(dt.unwrap_or_else(|| format!("Invalid timestamp ({timestamp})")))
+    }
+}
+
+/// Wrapper type for session IDs
+#[derive(Debug, Clone)]
+pub struct SessionId(i64);
+
+impl ToSql for SessionId {
+    fn to_sql(&self) -> bdk_wallet::rusqlite::Result<ToSqlOutput<'_>> {
+        self.0.to_sql()
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl SessionId {
+    pub fn as_i64(&self) -> i64 {
+        self.0
+    }
+}
+
+/// Persister for payjoin v2 send sessions
+#[derive(Clone)]
+pub struct SenderPersister {
+    db: Arc<Database>,
+    session_id: SessionId,
+}
+
+impl SenderPersister {
+    /// Creates a new sender persister, creating a new session in the database
+    pub fn new(db: Arc<Database>, receiver_pubkey: HpkePublicKey) -> Result<Self> {
+        let session_id: i64 = db.conn().query_row(
+            "INSERT INTO send_sessions (session_id, receiver_pubkey) VALUES (NULL, ?1) RETURNING session_id",
+            params![receiver_pubkey.to_compressed_bytes()],
+            |row| row.get(0),
+        )?;
+
+        Ok(Self {
+            db,
+            session_id: SessionId(session_id),
+        })
+    }
+
+    /// Creates a persister from an existing session ID
+    pub fn from_id(db: Arc<Database>, id: SessionId) -> Self {
+        Self { db, session_id: id }
+    }
+}
+
+impl SessionPersister for SenderPersister {
+    type SessionEvent = SenderSessionEvent;
+    type InternalStorageError = Error;
+
+    fn save_event(
+        &self,
+        event: SenderSessionEvent,
+    ) -> std::result::Result<(), Self::InternalStorageError> {
+        let event_data = serde_json::to_string(&event).map_err(Error::Serialize)?;
+
+        self.db.conn().execute(
+            "INSERT INTO send_session_events (session_id, event_data, created_at) VALUES (?1, ?2, ?3)",
+            params![self.session_id, event_data, now()],
+        )?;
+
+        Ok(())
+    }
+
+    fn load(
+        &self,
+    ) -> std::result::Result<Box<dyn Iterator<Item = SenderSessionEvent>>, Self::InternalStorageError>
+    {
+        let conn = self.db.conn();
+        let mut stmt = conn.prepare(
+            "SELECT event_data FROM send_session_events WHERE session_id = ?1 ORDER BY id ASC",
+        )?;
+
+        let event_rows = stmt.query_map(params![self.session_id], |row| {
+            let event_data: String = row.get(0)?;
+            Ok(event_data)
+        })?;
+
+        let events: Vec<SenderSessionEvent> = event_rows
+            .map(|row| {
+                let event_data = row.expect("Failed to read event data from database");
+                serde_json::from_str::<SenderSessionEvent>(&event_data)
+                    .expect("Database corruption: failed to deserialize session event")
+            })
+            .collect();
+
+        Ok(Box::new(events.into_iter()))
+    }
+
+    fn close(&self) -> std::result::Result<(), Self::InternalStorageError> {
+        self.db.conn().execute(
+            "UPDATE send_sessions SET completed_at = ?1 WHERE session_id = ?2",
+            params![now(), self.session_id],
+        )?;
+
+        Ok(())
+    }
+}
+
+/// Persister for payjoin v2 receive sessions
+#[derive(Clone)]
+pub struct ReceiverPersister {
+    db: Arc<Database>,
+    session_id: SessionId,
+}
+
+impl ReceiverPersister {
+    /// Creates a new receiver persister, creating a new session in the database
+    pub fn new(db: Arc<Database>) -> Result<Self> {
+        let session_id: i64 = db.conn().query_row(
+            "INSERT INTO receive_sessions (session_id) VALUES (NULL) RETURNING session_id",
+            [],
+            |row| row.get(0),
+        )?;
+
+        Ok(Self {
+            db,
+            session_id: SessionId(session_id),
+        })
+    }
+
+    /// Creates a persister from an existing session ID
+    pub fn from_id(db: Arc<Database>, id: SessionId) -> Self {
+        Self { db, session_id: id }
+    }
+}
+
+impl SessionPersister for ReceiverPersister {
+    type SessionEvent = ReceiverSessionEvent;
+    type InternalStorageError = Error;
+
+    fn save_event(
+        &self,
+        event: ReceiverSessionEvent,
+    ) -> std::result::Result<(), Self::InternalStorageError> {
+        let event_data = serde_json::to_string(&event).map_err(Error::Serialize)?;
+
+        self.db.conn().execute(
+            "INSERT INTO receive_session_events (session_id, event_data, created_at) VALUES (?1, ?2, ?3)",
+            params![self.session_id, event_data, now()],
+        )?;
+
+        Ok(())
+    }
+
+    fn load(
+        &self,
+    ) -> std::result::Result<
+        Box<dyn Iterator<Item = ReceiverSessionEvent>>,
+        Self::InternalStorageError,
+    > {
+        let conn = self.db.conn();
+        let mut stmt = conn.prepare(
+            "SELECT event_data FROM receive_session_events WHERE session_id = ?1 ORDER BY id ASC",
+        )?;
+
+        let event_rows = stmt.query_map(params![self.session_id], |row| {
+            let event_data: String = row.get(0)?;
+            Ok(event_data)
+        })?;
+
+        let events: Vec<ReceiverSessionEvent> = event_rows
+            .map(|row| {
+                let event_data = row.expect("Failed to read event data from database");
+                serde_json::from_str::<ReceiverSessionEvent>(&event_data)
+                    .expect("Database corruption: failed to deserialize session event")
+            })
+            .collect();
+
+        Ok(Box::new(events.into_iter()))
+    }
+
+    fn close(&self) -> std::result::Result<(), Self::InternalStorageError> {
+        self.db.conn().execute(
+            "UPDATE receive_sessions SET completed_at = ?1 WHERE session_id = ?2",
+            params![now(), self.session_id],
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/payjoin/mod.rs
+++ b/src/payjoin/mod.rs
@@ -548,6 +548,7 @@ impl<'a> PayjoinManager<'a> {
         let candidate_inputs: Vec<InputPair> = self
             .wallet
             .list_unspent()
+            .filter(|output| output.chain_position.is_confirmed())
             .map(|output| {
                 let psbtin = self
                     .wallet

--- a/src/payjoin/mod.rs
+++ b/src/payjoin/mod.rs
@@ -44,6 +44,60 @@ pub(crate) struct PayjoinManager<'a> {
     relay_manager: Arc<Mutex<RelayManager>>,
     db: Arc<crate::payjoin::db::Database>,
 }
+
+trait StatusText {
+    fn status_text(&self) -> &'static str;
+}
+
+impl StatusText for SendSession {
+    fn status_text(&self) -> &'static str {
+        match self {
+            SendSession::WithReplyKey(_) | SendSession::PollingForProposal(_) => {
+                "Waiting for proposal"
+            }
+            SendSession::Closed(session_outcome) => match session_outcome {
+                SenderSessionOutcome::Failure => "Session failure",
+                SenderSessionOutcome::Success(_) => "Session success",
+                SenderSessionOutcome::Cancel => "Session cancelled",
+            },
+        }
+    }
+}
+
+impl StatusText for ReceiveSession {
+    fn status_text(&self) -> &'static str {
+        match self {
+            ReceiveSession::Initialized(_) => "Waiting for original proposal",
+            ReceiveSession::UncheckedOriginalPayload(_)
+            | ReceiveSession::MaybeInputsOwned(_)
+            | ReceiveSession::MaybeInputsSeen(_)
+            | ReceiveSession::OutputsUnknown(_)
+            | ReceiveSession::WantsOutputs(_)
+            | ReceiveSession::WantsInputs(_)
+            | ReceiveSession::WantsFeeRange(_)
+            | ReceiveSession::ProvisionalProposal(_) => "Processing original proposal",
+            ReceiveSession::PayjoinProposal(_) => "Payjoin proposal sent",
+            ReceiveSession::HasReplyableError(_) => {
+                "Session failure, waiting to post error response"
+            }
+            ReceiveSession::Monitor(_) => "Monitoring payjoin proposal",
+            ReceiveSession::Closed(session_outcome) => match session_outcome {
+                ReceiverSessionOutcome::Failure => "Session failure",
+                ReceiverSessionOutcome::Success(_) => {
+                    "Session success, Payjoin proposal was broadcasted"
+                }
+                ReceiverSessionOutcome::Cancel => "Session cancelled",
+                ReceiverSessionOutcome::FallbackBroadcasted => "Fallback broadcasted",
+            },
+        }
+    }
+}
+
+struct SessionHistoryRow {
+    id: String,
+    role: &'static str,
+    status: String,
+    completed_at: Option<String>,
 }
 
 impl<'a> PayjoinManager<'a> {

--- a/src/payjoin/mod.rs
+++ b/src/payjoin/mod.rs
@@ -23,13 +23,10 @@ use payjoin::send::v2::{
 };
 use payjoin::{HpkePublicKey, ImplementationError, UriExt};
 use serde_json::{json, to_string_pretty};
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::{path::PathBuf, sync::Arc};
 
 use crate::payjoin::db::{ReceiverPersister, SenderPersister, open_payjoin_db};
-use crate::payjoin::ohttp::{RelayManager, fetch_ohttp_keys};
+use crate::payjoin::ohttp::RelayManager;
 
 pub mod db;
 pub mod ohttp;
@@ -41,7 +38,7 @@ pub mod ohttp;
 /// [`PayjoinManager::proceed_receiver_session`].
 pub(crate) struct PayjoinManager<'a> {
     wallet: &'a mut Wallet,
-    relay_manager: Arc<Mutex<RelayManager>>,
+    relay_manager: RelayManager,
     db: Arc<crate::payjoin::db::Database>,
 }
 
@@ -110,7 +107,7 @@ impl<'a> PayjoinManager<'a> {
         wallet_name: &str,
     ) -> Result<Self, Error> {
         let db = open_payjoin_db(datadir, wallet_name)?;
-        let relay_manager = Arc::new(Mutex::new(RelayManager::new()));
+        let relay_manager = RelayManager::new();
 
         Ok(Self {
             wallet,
@@ -137,14 +134,8 @@ impl<'a> PayjoinManager<'a> {
             .collect::<Result<_, _>>()
             .map_err(|e| Error::Generic(format!("Failed to parse one or more OHTTP URLs: {e}")))?;
 
-        if ohttp_relays.is_empty() {
-            return Err(Error::Generic(
-                "At least one valid OHTTP relay must be provided.".into(),
-            ));
-        }
-
-        let ohttp_keys =
-            fetch_ohttp_keys(ohttp_relays, &directory, self.relay_manager.clone()).await?;
+        self.relay_manager.configure(ohttp_relays)?;
+        let ohttp_keys = self.relay_manager.fetch_ohttp_keys(&directory).await?;
 
         let persister = crate::payjoin::db::ReceiverPersister::new(self.db.clone())?;
 
@@ -152,20 +143,17 @@ impl<'a> PayjoinManager<'a> {
             .map(FeeRate::from_sat_per_kwu)
             .unwrap_or(FeeRate::BROADCAST_MIN);
 
-        let receiver = payjoin::receive::v2::ReceiverBuilder::new(
-            address.address,
-            directory,
-            ohttp_keys.ohttp_keys,
-        )?
-        .with_amount(payjoin::bitcoin::Amount::from_sat(amount))
-        .with_max_fee_rate(checked_max_fee_rate)
-        .build()
-        .save(&persister)
-        .map_err(|e| {
-            Error::Generic(format!(
-                "Failed to persister the receiver after initialization: {e}"
-            ))
-        })?;
+        let receiver =
+            payjoin::receive::v2::ReceiverBuilder::new(address.address, directory, ohttp_keys)?
+                .with_amount(payjoin::bitcoin::Amount::from_sat(amount))
+                .with_max_fee_rate(checked_max_fee_rate)
+                .build()
+                .save(&persister)
+                .map_err(|e| {
+                    Error::Generic(format!(
+                        "Failed to persister the receiver after initialization: {e}"
+                    ))
+                })?;
 
         let pj_uri = receiver.pj_uri();
         println!("Request Payjoin by sharing this Payjoin Uri:");
@@ -174,7 +162,6 @@ impl<'a> PayjoinManager<'a> {
         self.proceed_receiver_session(
             ReceiveSession::Initialized(receiver.clone()),
             &persister,
-            ohttp_keys.relay_url.to_string(),
             checked_max_fee_rate,
             blockchain_client,
         )
@@ -244,11 +231,7 @@ impl<'a> PayjoinManager<'a> {
                         Error::Generic(format!("Failed to parse one or more OHTTP URLs: {e}"))
                     })?;
 
-                if ohttp_relays.is_empty() {
-                    return Err(Error::Generic(
-                        "At least one valid OHTTP relay must be provided.".into(),
-                    ));
-                }
+                self.relay_manager.configure(ohttp_relays)?;
                 // Check for existing session with the same receiver pubkey
                 let receiver_pubkey = v2_param.receiver_pubkey();
                 let existing_session =
@@ -293,13 +276,8 @@ impl<'a> PayjoinManager<'a> {
                     (SendSession::WithReplyKey(sender), persister)
                 };
 
-                self.proceed_sender_session(
-                    sender_state,
-                    &persister,
-                    ohttp_relays,
-                    blockchain_client,
-                )
-                .await?
+                self.proceed_sender_session(sender_state, &persister, blockchain_client)
+                    .await?
             }
             _ => {
                 unimplemented!("Payjoin version not recognized.");
@@ -313,20 +291,13 @@ impl<'a> PayjoinManager<'a> {
         &mut self,
         session: ReceiveSession,
         persister: &impl SessionPersister<SessionEvent = ReceiverSessionEvent>,
-        relay: impl payjoin::IntoUrl,
         max_fee_rate: FeeRate,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
         match session {
             ReceiveSession::Initialized(proposal) => {
-                self.read_from_directory(
-                    proposal,
-                    persister,
-                    relay,
-                    max_fee_rate,
-                    blockchain_client,
-                )
-                .await
+                self.read_from_directory(proposal, persister, max_fee_rate, blockchain_client)
+                    .await
             }
             ReceiveSession::UncheckedOriginalPayload(proposal) => {
                 self.check_proposal(proposal, persister, max_fee_rate, blockchain_client)
@@ -382,14 +353,14 @@ impl<'a> PayjoinManager<'a> {
         &mut self,
         receiver: Receiver<Initialized>,
         persister: &impl SessionPersister<SessionEvent = ReceiverSessionEvent>,
-        relay: impl payjoin::IntoUrl,
         max_fee_rate: FeeRate,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
         let mut current_receiver_typestate = receiver;
         let next_receiver_typestate = loop {
-            let (req, context) = current_receiver_typestate.create_poll_request(relay.as_str())?;
-            let response = self.send_payjoin_post_request(req).await?;
+            let (response, context) = self
+                .post_via_relay(|relay| current_receiver_typestate.create_poll_request(relay))
+                .await?;
             let state_transition = current_receiver_typestate
                 .process_response(response.bytes().await?.to_vec().as_slice(), context)
                 .save(persister);
@@ -630,17 +601,9 @@ impl<'a> PayjoinManager<'a> {
         persister: &impl SessionPersister<SessionEvent = ReceiverSessionEvent>,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
-        let (req, ctx) = receiver
-            .create_post_request(
-                self.unwrap_relay_or_else_fetch(vec![], None::<&str>)
-                    .await?
-                    .as_str(),
-            )
-            .map_err(|e| {
-                Error::Generic(format!("Error occurred when creating a post request for sending final Payjoin proposal: {e}"))
-            })?;
-
-        let res = self.send_payjoin_post_request(req).await?;
+        let (res, ctx) = self
+            .post_via_relay(|relay| receiver.create_post_request(relay))
+            .await?;
         let payjoin_psbt = receiver.psbt().clone();
         let next_receiver_typestate = receiver
             .process_response(&res.bytes().await?, ctx)
@@ -731,28 +694,9 @@ impl<'a> PayjoinManager<'a> {
         receiver: Receiver<HasReplyableError>,
         persister: &impl SessionPersister<SessionEvent = ReceiverSessionEvent>,
     ) -> Result<(), Error> {
-        let (err_req, err_ctx) = receiver
-            .create_error_request(
-                self.unwrap_relay_or_else_fetch(vec![], None::<&str>)
-                    .await?
-                    .as_str(),
-            )
-            .map_err(|e| {
-                Error::Generic(format!(
-                    "Error occurred when creating a receiver error request: {}",
-                    e
-                ))
-            })?;
-
-        let err_response = match self.send_payjoin_post_request(err_req).await {
-            Ok(response) => response,
-            Err(e) => {
-                return Err(Error::Generic(format!(
-                    "Failed to post error request: {}",
-                    e
-                )));
-            }
-        };
+        let (err_response, err_ctx) = self
+            .post_via_relay(|relay| receiver.create_error_request(relay))
+            .await?;
 
         let err_bytes = match err_response.bytes().await {
             Ok(bytes) => bytes,
@@ -781,33 +725,16 @@ impl<'a> PayjoinManager<'a> {
         &self,
         session: SendSession,
         persister: &impl SessionPersister<SessionEvent = SenderSessionEvent>,
-        ohttp_relays: Vec<url::Url>,
         blockchain_client: &BlockchainClient,
     ) -> Result<Txid, Error> {
         match session {
             SendSession::WithReplyKey(context) => {
-                let relay = self
-                    .unwrap_relay_or_else_fetch(ohttp_relays, Some(context.endpoint()))
-                    .await?;
-                self.post_original_proposal(
-                    context,
-                    persister,
-                    blockchain_client,
-                    relay.to_string(),
-                )
-                .await
+                self.post_original_proposal(context, persister, blockchain_client)
+                    .await
             }
             SendSession::PollingForProposal(context) => {
-                let relay = self
-                    .unwrap_relay_or_else_fetch(ohttp_relays, Some(context.endpoint()))
-                    .await?;
-                self.get_proposed_payjoin_proposal(
-                    context,
-                    persister,
-                    blockchain_client,
-                    relay.to_string(),
-                )
-                .await
+                self.get_proposed_payjoin_proposal(context, persister, blockchain_client)
+                    .await
             }
             SendSession::Closed(SenderSessionOutcome::Success(psbt)) => {
                 self.process_payjoin_proposal(psbt, blockchain_client).await
@@ -816,44 +743,19 @@ impl<'a> PayjoinManager<'a> {
         }
     }
 
-    async fn unwrap_relay_or_else_fetch(
-        &self,
-        ohttp_relays: Vec<url::Url>,
-        directory: Option<impl payjoin::IntoUrl>,
-    ) -> Result<url::Url, Error> {
-        let selected_relay = self
-            .relay_manager
-            .lock()
-            .expect("Lock should not be poisoned")
-            .get_selected_relay();
-        match selected_relay {
-            Some(relay) => Ok(relay),
-            None => {
-                let directory = directory.ok_or_else(|| {
-                    Error::Generic("No directory URL provided and no relay selected".to_string())
-                })?;
-                Ok(
-                    fetch_ohttp_keys(ohttp_relays, directory, self.relay_manager.clone())
-                        .await?
-                        .relay_url,
-                )
-            }
-        }
-    }
-
     async fn post_original_proposal(
         &self,
         sender: Sender<WithReplyKey>,
         persister: &impl SessionPersister<SessionEvent = SenderSessionEvent>,
         blockchain_client: &BlockchainClient,
-        relay: impl payjoin::IntoUrl,
     ) -> Result<Txid, Error> {
-        let (req, ctx) = sender.create_v2_post_request(relay.as_str())?;
-        let response = self.send_payjoin_post_request(req).await?;
+        let (response, ctx) = self
+            .post_via_relay(|relay| sender.create_v2_post_request(relay))
+            .await?;
         let sender = sender
             .process_response(&response.bytes().await?, ctx)
             .save(persister)?;
-        self.get_proposed_payjoin_proposal(sender, persister, blockchain_client, relay)
+        self.get_proposed_payjoin_proposal(sender, persister, blockchain_client)
             .await
     }
 
@@ -862,12 +764,12 @@ impl<'a> PayjoinManager<'a> {
         sender: Sender<PollingForProposal>,
         persister: &impl SessionPersister<SessionEvent = SenderSessionEvent>,
         blockchain_client: &BlockchainClient,
-        relay: impl payjoin::IntoUrl,
     ) -> Result<Txid, Error> {
         let mut sender = sender.clone();
         loop {
-            let (req, ctx) = sender.create_poll_request(relay.as_str())?;
-            let response = self.send_payjoin_post_request(req).await?;
+            let (response, ctx) = self
+                .post_via_relay(|relay| sender.create_poll_request(relay))
+                .await?;
             let processed_response = sender
                 .process_response(&response.bytes().await?, ctx)
                 .save(persister);
@@ -914,13 +816,36 @@ impl<'a> PayjoinManager<'a> {
             .header("Content-Type", req.content_type)
             .body(req.body)
             .send()
-            .await
+            .await?
+            .error_for_status()
+    }
+
+    async fn post_via_relay<F, T, E>(&self, mut build: F) -> Result<(reqwest::Response, T), Error>
+    where
+        F: FnMut(&str) -> Result<(payjoin::Request, T), E>,
+        E: std::fmt::Display,
+    {
+        loop {
+            let relay = self.relay_manager.choose_relay()?;
+            // Build a fresh request for each attempt. Reusing an OHTTP
+            // ciphertext would let relays correlate retransmissions.
+            let (req, context) = build(relay.as_str())
+                .map_err(|e| Error::Generic(format!("Failed to create OHTTP request: {e}")))?;
+
+            match self.send_payjoin_post_request(req).await {
+                Ok(response) => return Ok((response, context)),
+                Err(e) => {
+                    tracing::debug!("Request to OHTTP relay {relay} failed: {e:?}");
+                    self.relay_manager.add_failed_relay(relay);
+                }
+            }
+        }
     }
 
     /// Resume pending payjoin sessions from the database
     pub async fn resume_payjoins(
         &mut self,
-        directory: String,
+        _directory: String,
         ohttp_relays: Vec<String>,
         session_id: Option<i64>,
         blockchain_client: &BlockchainClient,
@@ -951,10 +876,7 @@ impl<'a> PayjoinManager<'a> {
             .map(|s| url::Url::parse(&s))
             .collect::<Result<_, _>>()
             .map_err(|e| Error::Generic(format!("Failed to parse OHTTP URLs: {e}")))?;
-
-        let relay = self
-            .unwrap_relay_or_else_fetch(ohttp_relays, Some(&directory))
-            .await?;
+        self.relay_manager.configure(ohttp_relays)?;
 
         let max_fee_rate = FeeRate::BROADCAST_MIN;
         let total_sessions = recv_session_ids.len() + send_session_ids.len();
@@ -975,7 +897,6 @@ impl<'a> PayjoinManager<'a> {
                         self.proceed_receiver_session(
                             receiver_state,
                             &persister,
-                            relay.as_str(),
                             max_fee_rate,
                             blockchain_client,
                         ),
@@ -1010,12 +931,7 @@ impl<'a> PayjoinManager<'a> {
                     println!("Resuming sender session {}", session_id);
                     match tokio::time::timeout(
                         std::time::Duration::from_secs(30),
-                        self.proceed_sender_session(
-                            sender_state,
-                            &persister,
-                            vec![relay.clone()],
-                            blockchain_client,
-                        ),
+                        self.proceed_sender_session(sender_state, &persister, blockchain_client),
                     )
                     .await
                     {

--- a/src/payjoin/mod.rs
+++ b/src/payjoin/mod.rs
@@ -88,6 +88,9 @@ impl StatusText for ReceiveSession {
                 }
                 ReceiverSessionOutcome::Cancel => "Session cancelled",
                 ReceiverSessionOutcome::FallbackBroadcasted => "Fallback broadcasted",
+                ReceiverSessionOutcome::PayjoinProposalSent => {
+                    "Payjoin proposal sent, skipping monitoring as the sender is spending non-SegWit inputs"
+                }
             },
         }
     }
@@ -694,13 +697,6 @@ impl<'a> PayjoinManager<'a> {
                                         return Ok(Some(tx_details.tx.as_ref().clone()));
                                     }
                                 Err(ImplementationError::from("Cannot find the transaction in the mempool or the blockchain"))
-                                },
-                                |outpoint| {
-                                    let utxo = self.wallet.get_utxo(outpoint);
-                                    match utxo {
-                                        Some(_) => Ok(false),
-                                        None => Ok(true),
-                                    }
                                 }
                             )
                             .save(persister);

--- a/src/payjoin/mod.rs
+++ b/src/payjoin/mod.rs
@@ -5,44 +5,61 @@ use bdk_wallet::{
     SignOptions, Wallet,
     bitcoin::{FeeRate, Psbt, Txid, consensus::encode::serialize_hex},
 };
+use cli_table::{Cell, CellStruct, Style, Table};
 use payjoin::bitcoin::TxIn;
 use payjoin::persist::{OptionalTransitionOutcome, SessionPersister};
 use payjoin::receive::InputPair;
 use payjoin::receive::v2::{
     HasReplyableError, Initialized, MaybeInputsOwned, MaybeInputsSeen, Monitor, OutputsUnknown,
     PayjoinProposal, ProvisionalProposal, ReceiveSession, Receiver,
-    SessionEvent as ReceiverSessionEvent, UncheckedOriginalPayload, WantsFeeRange, WantsInputs,
-    WantsOutputs,
+    SessionEvent as ReceiverSessionEvent, SessionOutcome as ReceiverSessionOutcome,
+    UncheckedOriginalPayload, WantsFeeRange, WantsInputs, WantsOutputs,
+    replay_event_log as replay_receiver_event_log,
 };
 use payjoin::send::v2::{
     PollingForProposal, SendSession, Sender, SessionEvent as SenderSessionEvent,
     SessionOutcome as SenderSessionOutcome, WithReplyKey,
+    replay_event_log as replay_sender_event_log,
 };
-use payjoin::{ImplementationError, UriExt};
+use payjoin::{HpkePublicKey, ImplementationError, UriExt};
 use serde_json::{json, to_string_pretty};
-use std::sync::{Arc, Mutex};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
+use crate::payjoin::db::{ReceiverPersister, SenderPersister, open_payjoin_db};
 use crate::payjoin::ohttp::{RelayManager, fetch_ohttp_keys};
 
+pub mod db;
 pub mod ohttp;
 
-/// Implements all of the functions required to go through the Payjoin receive and send processes.
+/// Coordinates Payjoin receive and send flows.
 ///
-/// TODO: At the time of writing, this struct is written to make a Persister implementation easier
-/// but the persister is not implemented yet! For instance [`PayjoinManager::proceed_sender_session`] and
-/// [`PayjoinManager::proceed_receiver_session`] are designed such that the manager can enable
-/// resuming ongoing payjoins are well. So... this is a TODO for implementing persister.
+/// The manager owns the wallet, relay manager, and database handles needed to persist session
+/// events and resume ongoing Payjoins through [`PayjoinManager::proceed_sender_session`] and
+/// [`PayjoinManager::proceed_receiver_session`].
 pub(crate) struct PayjoinManager<'a> {
     wallet: &'a mut Wallet,
     relay_manager: Arc<Mutex<RelayManager>>,
+    db: Arc<crate::payjoin::db::Database>,
+}
 }
 
 impl<'a> PayjoinManager<'a> {
-    pub fn new(wallet: &'a mut Wallet, relay_manager: Arc<Mutex<RelayManager>>) -> Self {
-        Self {
+    pub fn new(
+        wallet: &'a mut Wallet,
+        datadir: Option<PathBuf>,
+        wallet_name: &str,
+    ) -> Result<Self, Error> {
+        let db = open_payjoin_db(datadir, wallet_name)?;
+        let relay_manager = Arc::new(Mutex::new(RelayManager::new()));
+
+        Ok(Self {
             wallet,
             relay_manager,
-        }
+            db,
+        })
     }
 
     pub async fn receive_payjoin(
@@ -71,8 +88,8 @@ impl<'a> PayjoinManager<'a> {
 
         let ohttp_keys =
             fetch_ohttp_keys(ohttp_relays, &directory, self.relay_manager.clone()).await?;
-        // TODO: Implement proper persister.
-        let persister = payjoin::persist::NoopSessionPersister::<ReceiverSessionEvent>::default();
+
+        let persister = crate::payjoin::db::ReceiverPersister::new(self.db.clone())?;
 
         let checked_max_fee_rate = max_fee_rate
             .map(FeeRate::from_sat_per_kwu)
@@ -161,7 +178,7 @@ impl<'a> PayjoinManager<'a> {
                 self.process_payjoin_proposal(psbt, blockchain_client)
                     .await?
             }
-            payjoin::PjParam::V2(_) => {
+            payjoin::PjParam::V2(v2_param) => {
                 let ohttp_relays: Vec<url::Url> = ohttp_relays
                     .into_iter()
                     .map(|s| url::Url::parse(&s))
@@ -175,29 +192,54 @@ impl<'a> PayjoinManager<'a> {
                         "At least one valid OHTTP relay must be provided.".into(),
                     ));
                 }
+                // Check for existing session with the same receiver pubkey
+                let receiver_pubkey = v2_param.receiver_pubkey();
+                let existing_session =
+                    self.db
+                        .get_send_session_ids()?
+                        .into_iter()
+                        .find_map(|session_id| {
+                            let session_receiver_pubkey = self
+                                .db
+                                .get_send_session_receiver_pk(&session_id)
+                                .expect("Receiver pubkey should exist if session id exists");
+                            if session_receiver_pubkey == *receiver_pubkey {
+                                Some(session_id)
+                            } else {
+                                None
+                            }
+                        });
 
-                // TODO: Implement proper persister.
-                let persister =
-                    payjoin::persist::NoopSessionPersister::<SenderSessionEvent>::default();
+                let (sender_state, persister) = if let Some(session_id) = existing_session {
+                    let sender_persister = SenderPersister::from_id(self.db.clone(), session_id);
+                    let (send_session, _) =
+                        replay_sender_event_log(&sender_persister).map_err(|e| {
+                            Error::Generic(format!("Failed to replay sender event log: {e:?}"))
+                        })?;
+                    println!("Resuming existing sender session");
+                    (send_session, sender_persister)
+                } else {
+                    let persister = {
+                        let receiver_pubkey: HpkePublicKey = v2_param.receiver_pubkey().clone();
+                        SenderPersister::new(self.db.clone(), receiver_pubkey)?
+                    };
 
-                let sender = payjoin::send::v2::SenderBuilder::new(original_psbt.clone(), uri)
-                    .build_recommended(fee_rate)?
-                    .save(&persister)
-                    .map_err(|e| {
-                        Error::Generic(format!(
-                            "Failed to save the Payjoin v2 sender in the persister: {e}"
-                        ))
-                    })?;
+                    let sender = payjoin::send::v2::SenderBuilder::new(original_psbt.clone(), uri)
+                        .build_recommended(fee_rate)?
+                        .save(&persister)
+                        .map_err(|e| {
+                            Error::Generic(format!(
+                                "Failed to save the Payjoin v2 sender in the persister: {e}"
+                            ))
+                        })?;
 
-                let selected_relay =
-                    fetch_ohttp_keys(ohttp_relays, &sender.endpoint(), self.relay_manager.clone())
-                        .await?
-                        .relay_url;
+                    (SendSession::WithReplyKey(sender), persister)
+                };
 
                 self.proceed_sender_session(
-                    SendSession::WithReplyKey(sender),
+                    sender_state,
                     &persister,
-                    selected_relay.to_string(),
+                    ohttp_relays,
                     blockchain_client,
                 )
                 .await?
@@ -360,13 +402,8 @@ impl<'a> PayjoinManager<'a> {
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
         let next_receiver_typestate = receiver
-            .check_inputs_not_owned(&mut |input| {
-                Ok(self.wallet.is_mine(input.to_owned()))
-            })
-            .save(persister)
-            .map_err(|e| {
-                Error::Generic(format!("Error occurred when saving after checking if inputs in the original proposal are not owned: {e}"))
-            })?;
+            .check_inputs_not_owned(&mut |input| Ok(self.wallet.is_mine(input.to_owned())))
+            .save(persister)?;
 
         self.check_no_inputs_seen_before(
             next_receiver_typestate,
@@ -384,16 +421,11 @@ impl<'a> PayjoinManager<'a> {
         max_fee_rate: FeeRate,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
-        // This is not supported as there is no persistence of previous Payjoin attempts in BDK CLI
-        // yet. If there is support either in the BDK persister or Payjoin persister, this can be
-        // implemented, but it is not a concern as the use cases of the CLI does not warrant
-        // protection against probing attacks.
-        println!(
-            "Checking whether the inputs in the proposal were seen before to protect from probing attacks is not supported. Skipping the check..."
-        );
-        let next_receiver_typestate = receiver.check_no_inputs_seen_before(&mut |_| Ok(false)).save(persister).map_err(|e| {
-            Error::Generic(format!("Error occurred when saving after checking if the inputs in the proposal were seen before: {e}"))
-        })?;
+        let db = self.db.clone();
+        let next_receiver_typestate = receiver
+            .check_no_inputs_seen_before(&mut |input| Ok(db.insert_input_seen_before(*input)?))
+            .save(persister)?;
+
         self.identify_receiver_outputs(
             next_receiver_typestate,
             persister,
@@ -410,11 +442,11 @@ impl<'a> PayjoinManager<'a> {
         max_fee_rate: FeeRate,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
-        let next_receiver_typestate = receiver.identify_receiver_outputs(&mut |output_script| {
-            Ok(self.wallet.is_mine(output_script.to_owned()))
-        }).save(persister).map_err(|e| {
-            Error::Generic(format!("Error occurred when saving after checking if the outputs in the original proposal are owned by the receiver: {e}"))
-        })?;
+        let next_receiver_typestate = receiver
+            .identify_receiver_outputs(&mut |output_script| {
+                Ok(self.wallet.is_mine(output_script.to_owned()))
+            })
+            .save(persister)?;
 
         self.commit_outputs(
             next_receiver_typestate,
@@ -498,9 +530,9 @@ impl<'a> PayjoinManager<'a> {
         max_fee_rate: FeeRate,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
-        let next_receiver_typestate = receiver.apply_fee_range(None, Some(max_fee_rate)).save(persister).map_err(|e| {
-            Error::Generic(format!("Error occurred when saving after applying the receiver fee range to the transaction: {e}"))
-        })?;
+        let next_receiver_typestate = receiver
+            .apply_fee_range(None, Some(max_fee_rate))
+            .save(persister)?;
         self.finalize_proposal(next_receiver_typestate, persister, blockchain_client)
             .await
     }
@@ -528,12 +560,7 @@ impl<'a> PayjoinManager<'a> {
 
                 Ok(psbt_clone)
             })
-            .save(persister)
-            .map_err(|e| {
-                Error::Generic(format!(
-                    "Error occurred when saving after signing the Payjoin proposal: {e}"
-                ))
-            })?;
+            .save(persister)?;
 
         self.send_payjoin_proposal(next_receiver_typestate, persister, blockchain_client)
             .await
@@ -545,22 +572,21 @@ impl<'a> PayjoinManager<'a> {
         persister: &impl SessionPersister<SessionEvent = ReceiverSessionEvent>,
         blockchain_client: &BlockchainClient,
     ) -> Result<(), Error> {
-        let (req, ctx) = receiver.create_post_request(
-            self.relay_manager
-                .lock()
-                .expect("Lock should not be poisoned")
-                .get_selected_relay()
-                .expect("A relay should already be selected")
-                .as_str(),
-        ).map_err(|e| {
+        let (req, ctx) = receiver
+            .create_post_request(
+                self.unwrap_relay_or_else_fetch(vec![], None::<&str>)
+                    .await?
+                    .as_str(),
+            )
+            .map_err(|e| {
                 Error::Generic(format!("Error occurred when creating a post request for sending final Payjoin proposal: {e}"))
             })?;
 
         let res = self.send_payjoin_post_request(req).await?;
         let payjoin_psbt = receiver.psbt().clone();
-        let next_receiver_typestate = receiver.process_response(&res.bytes().await?, ctx).save(persister).map_err(|e| {
-            Error::Generic(format!("Error occurred when saving after processing the response to the Payjoin proposal send: {e}"))
-        })?;
+        let next_receiver_typestate = receiver
+            .process_response(&res.bytes().await?, ctx)
+            .save(persister)?;
         println!(
             "Response successful. TXID: {}",
             payjoin_psbt.extract_tx_unchecked_fee_rate().compute_txid()
@@ -623,10 +649,7 @@ impl<'a> PayjoinManager<'a> {
                                     }
                                 }
                             )
-                            .save(persister)
-                            .map_err(|e| {
-                                Error::Generic(format!("Error occurred when saving after checking that sender has broadcasted the Payjoin transaction: {e}"))
-                            });
+                            .save(persister);
 
                         if let Ok(OptionalTransitionOutcome::Progress(_)) = check_result {
                             println!("Payjoin transaction detected in the mempool!");
@@ -659,11 +682,8 @@ impl<'a> PayjoinManager<'a> {
     ) -> Result<(), Error> {
         let (err_req, err_ctx) = receiver
             .create_error_request(
-                self.relay_manager
-                    .lock()
-                    .expect("Lock should not be poisoned")
-                    .get_selected_relay()
-                    .expect("A relay should already be selected")
+                self.unwrap_relay_or_else_fetch(vec![], None::<&str>)
+                    .await?
                     .as_str(),
             )
             .map_err(|e| {
@@ -710,17 +730,33 @@ impl<'a> PayjoinManager<'a> {
         &self,
         session: SendSession,
         persister: &impl SessionPersister<SessionEvent = SenderSessionEvent>,
-        relay: impl payjoin::IntoUrl,
+        ohttp_relays: Vec<url::Url>,
         blockchain_client: &BlockchainClient,
     ) -> Result<Txid, Error> {
         match session {
             SendSession::WithReplyKey(context) => {
-                self.post_original_proposal(context, relay, persister, blockchain_client)
-                    .await
+                let relay = self
+                    .unwrap_relay_or_else_fetch(ohttp_relays, Some(context.endpoint()))
+                    .await?;
+                self.post_original_proposal(
+                    context,
+                    persister,
+                    blockchain_client,
+                    relay.to_string(),
+                )
+                .await
             }
             SendSession::PollingForProposal(context) => {
-                self.get_proposed_payjoin_proposal(context, relay, persister, blockchain_client)
-                    .await
+                let relay = self
+                    .unwrap_relay_or_else_fetch(ohttp_relays, Some(context.endpoint()))
+                    .await?;
+                self.get_proposed_payjoin_proposal(
+                    context,
+                    persister,
+                    blockchain_client,
+                    relay.to_string(),
+                )
+                .await
             }
             SendSession::Closed(SenderSessionOutcome::Success(psbt)) => {
                 self.process_payjoin_proposal(psbt, blockchain_client).await
@@ -729,31 +765,53 @@ impl<'a> PayjoinManager<'a> {
         }
     }
 
+    async fn unwrap_relay_or_else_fetch(
+        &self,
+        ohttp_relays: Vec<url::Url>,
+        directory: Option<impl payjoin::IntoUrl>,
+    ) -> Result<url::Url, Error> {
+        let selected_relay = self
+            .relay_manager
+            .lock()
+            .expect("Lock should not be poisoned")
+            .get_selected_relay();
+        match selected_relay {
+            Some(relay) => Ok(relay),
+            None => {
+                let directory = directory.ok_or_else(|| {
+                    Error::Generic("No directory URL provided and no relay selected".to_string())
+                })?;
+                Ok(
+                    fetch_ohttp_keys(ohttp_relays, directory, self.relay_manager.clone())
+                        .await?
+                        .relay_url,
+                )
+            }
+        }
+    }
+
     async fn post_original_proposal(
         &self,
         sender: Sender<WithReplyKey>,
-        relay: impl payjoin::IntoUrl,
         persister: &impl SessionPersister<SessionEvent = SenderSessionEvent>,
         blockchain_client: &BlockchainClient,
+        relay: impl payjoin::IntoUrl,
     ) -> Result<Txid, Error> {
         let (req, ctx) = sender.create_v2_post_request(relay.as_str())?;
         let response = self.send_payjoin_post_request(req).await?;
         let sender = sender
             .process_response(&response.bytes().await?, ctx)
-            .save(persister)
-        .map_err(|e| {
-                Error::Generic(format!("Failed to persist the Payjoin send after successfully sending original proposal: {e}"))
-            })?;
-        self.get_proposed_payjoin_proposal(sender, relay, persister, blockchain_client)
+            .save(persister)?;
+        self.get_proposed_payjoin_proposal(sender, persister, blockchain_client, relay)
             .await
     }
 
     async fn get_proposed_payjoin_proposal(
         &self,
         sender: Sender<PollingForProposal>,
-        relay: impl payjoin::IntoUrl,
         persister: &impl SessionPersister<SessionEvent = SenderSessionEvent>,
         blockchain_client: &BlockchainClient,
+        relay: impl payjoin::IntoUrl,
     ) -> Result<Txid, Error> {
         let mut sender = sender.clone();
         loop {
@@ -806,5 +864,253 @@ impl<'a> PayjoinManager<'a> {
             .body(req.body)
             .send()
             .await
+    }
+
+    /// Resume pending payjoin sessions from the database
+    pub async fn resume_payjoins(
+        &mut self,
+        directory: String,
+        ohttp_relays: Vec<String>,
+        session_id: Option<i64>,
+        blockchain_client: &BlockchainClient,
+    ) -> Result<String, Error> {
+        let db = self.db.clone();
+        let mut recv_session_ids = db.get_recv_session_ids()?;
+        let mut send_session_ids = db.get_send_session_ids()?;
+
+        if let Some(session_id) = session_id {
+            recv_session_ids.retain(|id| id.as_i64() == session_id);
+            send_session_ids.retain(|id| id.as_i64() == session_id);
+
+            if recv_session_ids.is_empty() && send_session_ids.is_empty() {
+                return Ok(serde_json::to_string_pretty(&json!({
+                    "message": format!("No active session found for session_id {}.", session_id)
+                }))?);
+            }
+        }
+
+        if recv_session_ids.is_empty() && send_session_ids.is_empty() {
+            return Ok(serde_json::to_string_pretty(&json!({
+                "message": "No sessions to resume."
+            }))?);
+        }
+
+        let ohttp_relays: Vec<url::Url> = ohttp_relays
+            .into_iter()
+            .map(|s| url::Url::parse(&s))
+            .collect::<Result<_, _>>()
+            .map_err(|e| Error::Generic(format!("Failed to parse OHTTP URLs: {e}")))?;
+
+        let relay = self
+            .unwrap_relay_or_else_fetch(ohttp_relays, Some(&directory))
+            .await?;
+
+        let max_fee_rate = FeeRate::BROADCAST_MIN;
+        let total_sessions = recv_session_ids.len() + send_session_ids.len();
+        let mut completed = 0usize;
+        let mut timed_out = 0usize;
+        let mut failed = 0usize;
+
+        println!("Resuming {} payjoin session(s)...\n", total_sessions);
+
+        // Resume receiver sessions
+        for session_id in recv_session_ids {
+            let persister = ReceiverPersister::from_id(db.clone(), session_id.clone());
+            match replay_receiver_event_log(&persister) {
+                Ok((receiver_state, _)) => {
+                    println!("Resuming receiver session {}", session_id);
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(30),
+                        self.proceed_receiver_session(
+                            receiver_state,
+                            &persister,
+                            relay.as_str(),
+                            max_fee_rate,
+                            blockchain_client,
+                        ),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {
+                            completed += 1;
+                        }
+                        Ok(Err(e)) => {
+                            failed += 1;
+                            println!("Receiver session {} failed: {}", session_id, e);
+                        }
+                        Err(_) => {
+                            timed_out += 1;
+                            println!("Receiver session {} timed out", session_id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    failed += 1;
+                    println!("Failed to replay receiver session {}: {:?}", session_id, e);
+                }
+            }
+        }
+
+        // Resume sender sessions
+        for session_id in send_session_ids {
+            let persister = SenderPersister::from_id(db.clone(), session_id.clone());
+            match replay_sender_event_log(&persister) {
+                Ok((sender_state, _)) => {
+                    println!("Resuming sender session {}", session_id);
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(30),
+                        self.proceed_sender_session(
+                            sender_state,
+                            &persister,
+                            vec![relay.clone()],
+                            blockchain_client,
+                        ),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {
+                            completed += 1;
+                        }
+                        Ok(Err(e)) => {
+                            failed += 1;
+                            println!("Sender session {} failed: {}", session_id, e);
+                        }
+                        Err(_) => {
+                            timed_out += 1;
+                            println!("Sender session {} timed out", session_id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    failed += 1;
+                    println!("Failed to replay sender session {}: {:?}", session_id, e);
+                }
+            }
+        }
+
+        Ok(serde_json::to_string_pretty(&json!({
+            "message": format!("Resumed polling for {} session(s).", total_sessions),
+            "outcome": format!(
+                "Completed: {}, timed out: {}, failed: {}.",
+                completed, timed_out, failed
+            )
+        }))?)
+    }
+
+    /// Show payjoin session history
+    pub fn history(
+        datadir: Option<std::path::PathBuf>,
+        wallet_name: &str,
+    ) -> Result<String, Error> {
+        let db = open_payjoin_db(datadir, wallet_name)?;
+        let mut send_rows: Vec<SessionHistoryRow> = Vec::new();
+        let mut recv_rows: Vec<SessionHistoryRow> = Vec::new();
+
+        // Active send sessions
+        for session_id in db
+            .get_send_session_ids()
+            .map_err(|e| Error::Generic(format!("{e}")))?
+        {
+            let persister = SenderPersister::from_id(db.clone(), session_id.clone());
+            let status = match replay_sender_event_log(&persister) {
+                Ok((state, _)) => state.status_text().to_string(),
+                Err(e) => e.to_string(),
+            };
+            send_rows.push(SessionHistoryRow {
+                id: session_id.to_string(),
+                role: "Sender",
+                status,
+                completed_at: None,
+            });
+        }
+
+        // Active receive sessions
+        for session_id in db
+            .get_recv_session_ids()
+            .map_err(|e| Error::Generic(format!("{e}")))?
+        {
+            let persister = ReceiverPersister::from_id(db.clone(), session_id.clone());
+            let status = match replay_receiver_event_log(&persister) {
+                Ok((state, _)) => state.status_text().to_string(),
+                Err(e) => e.to_string(),
+            };
+            recv_rows.push(SessionHistoryRow {
+                id: session_id.to_string(),
+                role: "Receiver",
+                status,
+                completed_at: None,
+            });
+        }
+
+        // Completed send sessions
+        for (session_id, completed_at) in db
+            .get_inactive_send_session_ids()
+            .map_err(|e| Error::Generic(format!("{e}")))?
+        {
+            let persister = SenderPersister::from_id(db.clone(), session_id.clone());
+            let status = match replay_sender_event_log(&persister) {
+                Ok((state, _)) => state.status_text().to_string(),
+                Err(e) => e.to_string(),
+            };
+            let completed_at = db
+                .format_unix_timestamp(completed_at)
+                .map_err(|e| Error::Generic(format!("{e}")))?;
+            send_rows.push(SessionHistoryRow {
+                id: session_id.to_string(),
+                role: "Sender",
+                status,
+                completed_at: Some(completed_at),
+            });
+        }
+
+        // Completed receive sessions
+        for (session_id, completed_at) in db
+            .get_inactive_recv_session_ids()
+            .map_err(|e| Error::Generic(format!("{e}")))?
+        {
+            let persister = ReceiverPersister::from_id(db.clone(), session_id.clone());
+            let status = match replay_receiver_event_log(&persister) {
+                Ok((state, _)) => state.status_text().to_string(),
+                Err(e) => e.to_string(),
+            };
+            let completed_at = db
+                .format_unix_timestamp(completed_at)
+                .map_err(|e| Error::Generic(format!("{e}")))?;
+            recv_rows.push(SessionHistoryRow {
+                id: session_id.to_string(),
+                role: "Receiver",
+                status,
+                completed_at: Some(completed_at),
+            });
+        }
+
+        let rows: Vec<Vec<CellStruct>> = send_rows
+            .iter()
+            .chain(recv_rows.iter())
+            .map(|row| {
+                vec![
+                    row.id.as_str().cell(),
+                    row.role.cell(),
+                    row.completed_at
+                        .clone()
+                        .unwrap_or_else(|| "Not Completed".to_string())
+                        .cell(),
+                    row.status.as_str().cell(),
+                ]
+            })
+            .collect();
+
+        let table = rows
+            .table()
+            .title(vec![
+                "Session ID".cell().bold(true),
+                "Sender/Receiver".cell().bold(true),
+                "Completed At".cell().bold(true),
+                "Status".cell().bold(true),
+            ])
+            .display()
+            .map_err(|e| Error::Generic(e.to_string()))?;
+
+        Ok(format!("{table}"))
     }
 }

--- a/src/payjoin/ohttp.rs
+++ b/src/payjoin/ohttp.rs
@@ -3,108 +3,125 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub(crate) struct RelayManager {
-    selected_relay: Option<url::Url>,
-    failed_relays: Vec<url::Url>,
+    relays: Vec<url::Url>,
+    failed_relays: Arc<Mutex<Vec<url::Url>>>,
 }
 
 impl RelayManager {
-    pub fn new() -> Self {
-        RelayManager {
-            selected_relay: None,
-            failed_relays: Vec::new(),
+    pub(crate) fn new() -> Self {
+        Self {
+            relays: Vec::new(),
+            failed_relays: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    pub fn set_selected_relay(&mut self, relay: url::Url) {
-        self.selected_relay = Some(relay);
-    }
-
-    pub fn get_selected_relay(&self) -> Option<url::Url> {
-        self.selected_relay.clone()
-    }
-
-    pub fn add_failed_relay(&mut self, relay: url::Url) {
-        self.failed_relays.push(relay);
-    }
-
-    pub fn get_failed_relays(&self) -> Vec<url::Url> {
-        self.failed_relays.clone()
-    }
-}
-
-pub(crate) struct ValidatedOhttpKeys {
-    pub(crate) ohttp_keys: payjoin::OhttpKeys,
-    pub(crate) relay_url: url::Url,
-}
-
-pub(crate) async fn fetch_ohttp_keys(
-    relays: Vec<url::Url>,
-    payjoin_directory: impl payjoin::IntoUrl,
-    relay_manager: Arc<Mutex<RelayManager>>,
-) -> Result<ValidatedOhttpKeys, Error> {
-    use payjoin::bitcoin::secp256k1::rand::prelude::SliceRandom;
-
-    loop {
-        let failed_relays = relay_manager
-            .lock()
-            .expect("Lock should not be poisoned")
-            .get_failed_relays();
-
-        let remaining_relays: Vec<_> = relays
-            .iter()
-            .filter(|r| !failed_relays.contains(r))
-            .cloned()
-            .collect();
-
-        if remaining_relays.is_empty() {
+    pub(crate) fn configure(&mut self, relays: Vec<url::Url>) -> Result<(), Error> {
+        if relays.is_empty() {
             return Err(Error::Generic(
-                "No valid OHTTP relays available".to_string(),
+                "At least one valid OHTTP relay must be provided.".into(),
             ));
         }
 
-        let selected_relay =
-            match remaining_relays.choose(&mut payjoin::bitcoin::key::rand::thread_rng()) {
-                Some(relay) => relay.clone(),
-                None => {
-                    return Err(Error::Generic(
-                        "Failed to select from remaining relays".to_string(),
-                    ));
-                }
-            };
-
-        relay_manager
+        self.relays = relays;
+        self.failed_relays
             .lock()
             .expect("Lock should not be poisoned")
-            .set_selected_relay(selected_relay.clone());
+            .clear();
+        Ok(())
+    }
 
-        let ohttp_keys =
-            payjoin::io::fetch_ohttp_keys(selected_relay.as_str(), payjoin_directory.as_str())
-                .await;
+    pub(crate) fn add_failed_relay(&self, relay: url::Url) {
+        let mut failed_relays = self
+            .failed_relays
+            .lock()
+            .expect("Lock should not be poisoned");
+        if !failed_relays.contains(&relay) {
+            failed_relays.push(relay);
+        }
+    }
 
-        match ohttp_keys {
-            Ok(keys) => {
-                return Ok(ValidatedOhttpKeys {
-                    ohttp_keys: keys,
-                    relay_url: selected_relay,
-                });
-            }
-            Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
-                return Err(Error::Generic(format!(
-                    "Unexpected error occurred when fetching OHTTP keys: {}",
-                    e
-                )));
-            }
-            Err(e) => {
-                tracing::debug!(
-                    "Failed to connect to OHTTP relay: {}, {}",
-                    selected_relay,
-                    e
-                );
-                relay_manager
-                    .lock()
-                    .expect("Lock should not be poisoned")
-                    .add_failed_relay(selected_relay);
+    pub(crate) fn choose_relay(&self) -> Result<url::Url, Error> {
+        use payjoin::bitcoin::secp256k1::rand::prelude::SliceRandom;
+
+        let failed_relays = self
+            .failed_relays
+            .lock()
+            .expect("Lock should not be poisoned");
+        let remaining_relays: Vec<_> = self
+            .relays
+            .iter()
+            .filter(|relay| !failed_relays.contains(relay))
+            .cloned()
+            .collect();
+
+        remaining_relays
+            .choose(&mut payjoin::bitcoin::key::rand::thread_rng())
+            .cloned()
+            .ok_or_else(|| Error::Generic("No valid OHTTP relays available".to_string()))
+    }
+
+    pub(crate) async fn fetch_ohttp_keys(
+        &self,
+        payjoin_directory: impl payjoin::IntoUrl,
+    ) -> Result<payjoin::OhttpKeys, Error> {
+        loop {
+            let selected_relay = self.choose_relay()?;
+            let ohttp_keys =
+                payjoin::io::fetch_ohttp_keys(selected_relay.as_str(), payjoin_directory.as_str())
+                    .await;
+
+            match ohttp_keys {
+                Ok(keys) => return Ok(keys),
+                Err(payjoin::io::Error::UnexpectedStatusCode(e)) => {
+                    return Err(Error::Generic(format!(
+                        "Unexpected error occurred when fetching OHTTP keys: {e}"
+                    )));
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Failed to connect to OHTTP relay: {}, {}",
+                        selected_relay,
+                        e
+                    );
+                    self.add_failed_relay(selected_relay);
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RelayManager;
+
+    fn relay(url: &str) -> url::Url {
+        url::Url::parse(url).expect("valid relay URL")
+    }
+
+    #[test]
+    fn choose_relay_excludes_failed_relays() {
+        let mut manager = RelayManager::new();
+        let failed = relay("https://failed.example");
+        let available = relay("https://available.example");
+        manager
+            .configure(vec![failed.clone(), available.clone()])
+            .expect("relay configuration");
+
+        manager.add_failed_relay(failed);
+
+        assert_eq!(manager.choose_relay().expect("available relay"), available);
+    }
+
+    #[test]
+    fn choose_relay_fails_when_all_relays_failed() {
+        let mut manager = RelayManager::new();
+        let failed = relay("https://failed.example");
+        manager
+            .configure(vec![failed.clone()])
+            .expect("relay configuration");
+
+        manager.add_failed_relay(failed);
+
+        assert!(manager.choose_relay().is_err());
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -175,7 +175,6 @@ pub(crate) fn prepare_wallet_db_dir(
 
     Ok(dir)
 }
-
 #[cfg(any(
     feature = "electrum",
     feature = "esplora",


### PR DESCRIPTION
### Description
https://github.com/bitcoindevkit/bdk-cli/pull/230 needed to be merged for this to go through
Address https://github.com/bitcoindevkit/bdk-cli/issues/149 also follow up to #200 
This PR adds persistance to existing async payjoin integration 
This introduces neccessary database model and tables also  add commad for resume to allow interrupted sessions to be continued also a particular session either send or receive.
A history commad to view payjoin history and status has been added
  
### Notes to the reviewers

Step to review this include making a payjoin transaction 

Run a receiver to get a BIP21 URI then pass it to the sender as seen in docs https://github.com/bitcoindevkit/bdk-cli/blob/b9cf2acc5f10db46fa30777ff0910b8610a5fc33/README.md?plain=1#L121-L141

To test resumption, interrupt either side with Ctrl+C mid-session then run resume on that side to continue. A few scenarios worth covering: receiver resuming after interrupt and sender resuming after interrupt. Use history after each scenario to confirm the session state was persisted correctly.

docs for this can be seen in 7e4ffd1d3ad1165a7d9187bcacb0bdab3303dbb3

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've added docs for the new feature
