### PR TITLE
Enforce use of `1.0.0-rc.1` payjoin version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bdk_esplora = { version = "0.22.1", features = ["async-https", "tokio"], optiona
 bdk_kyoto = { version = "0.15.1", optional = true }
 bdk_redb = { version = "0.1.0", optional = true }
 shlex = {  version = "1.3.0", optional = true }
-payjoin = { version = "1.0.0-rc.1", features = ["v1", "v2", "io", "_test-utils"], optional = true}
+payjoin = { version = "=1.0.0-rc.1", features = ["v1", "v2", "io", "_test-utils"], optional = true}
 reqwest = { version = "0.12.23", default-features = false, optional = true }
 url = { version = "2.5.4", optional = true }
 


### PR DESCRIPTION
**Description**

Cargo's version resolution always updates to the latest patch version. If that patch introduces breaking changes, it breaks your application.

This happened after Payjoin released version 1.0.0-rc.2. Because the version specified for bdk-cli was 1.0.0-rc.1, a fresh install automatically updated to the newer patch.

To resolve this without migrating to the latest Payjoin API, and to prevent future breakages from subsequent 1.0.0-rc.x releases, this commit pins the Payjoin version strictly to =1.0.0-rc.1.

This happened before in another project: rust-bitcoin/rust-bitcoin#5358

**Changelog notice**

```text
fix: enforce `1.0.0-rc.1` payjoin version and avoid automatic patch updates
```
