### PR TITLE
Add additional slash to show ReceivePayjoin cli docs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -444,7 +444,7 @@ pub enum OnlineWalletSubCommand {
         )]
         tx: Option<String>,
     },
-    // Generates a Payjoin receive URI and processes the sender's Payjoin proposal.
+    /// Generates a Payjoin receive URI and processes the sender's Payjoin proposal.
     ReceivePayjoin {
         /// Amount to be received in sats.
         #[arg(env = "PAYJOIN_AMOUNT", long = "amount", required = true)]


### PR DESCRIPTION
### Description

A missing slash was preventing the `receive_payjoin` command from displaying its documentation string:

```bash
Wallet operations.

...
  sync               Syncs with the chosen blockchain server
  broadcast          Broadcasts a transaction to the network. Takes either a raw transaction or a PSBT to extract
  receive_payjoin
  send_payjoin       Sends an original PSBT to a BIP 21 URI and broadcasts the returned Payjoin PSBT
  new_address        Get a new external address
...
```

This change adds the additional slash to make a proper doc string, so clap displays it. 