### PR TITLE
Feat: Add bip329 wallet labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "bdk_kyoto",
  "bdk_redb",
  "bdk_wallet",
+ "bip329",
  "clap",
  "clap_complete",
  "cli-table",
@@ -354,6 +355,18 @@ dependencies = [
  "chacha20-poly1305",
  "rand 0.8.5",
  "tokio",
+]
+
+[[package]]
+name = "bip329"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689260fce0f6e366877a624be4c87518e80f99951c421ae80c3be6523a51bc9d"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ shlex = {  version = "1.3.0", optional = true }
 payjoin = { version = "=1.0.0-rc.1", features = ["v1", "v2", "io", "_test-utils"], optional = true}
 reqwest = { version = "0.13.2", default-features = false, optional = true }
 url = { version = "2.5.8", optional = true }
+bip329 = "0.4.0"
 
 [features]
 default = ["repl", "sqlite"]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -477,6 +477,19 @@ pub enum OfflineWalletSubCommand {
         #[arg(long, conflicts_with_all = ["address", "txid"], required_unless_present_any = ["address", "txid"], value_parser = crate::utils::parse_outpoint)]
         utxo: Option<OutPoint>,
     },
+    /// Import from an existing BIP-329 JSONL label file, merging with current labels.
+    ImportLabels {
+        /// The jsonl label file path
+        #[arg(required = true)]
+        file: std::path::PathBuf,
+    },
+
+    /// Export current labels to a BIP-329 JSONL file.
+    ExportLabels {
+        /// The jsonl label file path
+        #[arg(required = true)]
+        file: std::path::PathBuf,
+    },
 }
 
 /// Wallet subcommands that needs a blockchain backend.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -14,7 +14,7 @@
 
 #![allow(clippy::large_enum_variant)]
 use bdk_wallet::bitcoin::{
-    Address, Network, OutPoint, ScriptBuf,
+    Address, Network, OutPoint, ScriptBuf, Txid,
     bip32::{DerivationPath, Xpriv},
 };
 use clap::{Args, Parser, Subcommand, ValueEnum, value_parser};
@@ -460,6 +460,22 @@ pub enum OfflineWalletSubCommand {
         /// Add one PSBT to combine. This option can be repeated multiple times, one for each PSBT.
         #[arg(env = "BASE64_PSBT", required = true)]
         psbt: Vec<String>,
+    },
+
+    /// Set a human-readable label for a wallet item (address, transaction, or UTXO).
+    Label {
+        /// The human-readable label string.
+        #[arg(env = "LABEL_STR", required = true)]
+        label_str: String,
+        /// The address to label.
+        #[arg(long, conflicts_with_all = ["txid", "utxo"], required_unless_present_any = ["txid", "utxo"], value_parser = crate::utils::parse_address)]
+        address: Option<Address>,
+        /// The transaction ID to label.
+        #[arg(long, conflicts_with_all = ["address", "utxo"], required_unless_present_any = ["address", "utxo"], value_parser = crate::utils::parse_txid)]
+        txid: Option<Txid>,
+        /// The UTXO (outpoint) to label.
+        #[arg(long, conflicts_with_all = ["address", "txid"], required_unless_present_any = ["address", "txid"], value_parser = crate::utils::parse_outpoint)]
+        utxo: Option<OutPoint>,
     },
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -231,6 +231,50 @@ pub fn handle_offline_wallet_subcommand(
                 }))?)
             }
         }
+        ImportLabels { file } => {
+            let imported_labels = bip329::Labels::try_from_file(&file).map_err(|e| {
+                Error::Generic(format!(
+                    "Failed to import labels from {}: {e}",
+                    file.display()
+                ))
+            })?;
+
+            for label in imported_labels.into_iter() {
+                add_or_update_label(labels, label);
+            }
+
+            if cli_opts.pretty {
+                Ok(format!(
+                    "Successfully imported labels from '{}'",
+                    file.display()
+                ))
+            } else {
+                Ok(serde_json::to_string_pretty(&json!({
+                    "message": "Labels successfully imported",
+                    "file": file.display().to_string()
+                }))?)
+            }
+        }
+        ExportLabels { file } => {
+            labels.export_to_file(&file).map_err(|e| {
+                Error::Generic(format!(
+                    "Failed to export labels to {}: {e}",
+                    file.display()
+                ))
+            })?;
+
+            if cli_opts.pretty {
+                Ok(format!(
+                    "Labels successfully exported to '{}'",
+                    file.display()
+                ))
+            } else {
+                Ok(serde_json::to_string_pretty(&json!({
+                    "message": "Labels successfully exported",
+                    "file": file.display().to_string()
+                }))?)
+            }
+        }
         Unspent => {
             let utxos = wallet.list_unspent().collect::<Vec<_>>();
             if cli_opts.pretty {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -92,12 +92,14 @@ use {
 };
 
 use bip329::LabelRef;
+use bip329::{AddressRecord, Label as BipLabel, OutputRecord, TransactionRecord};
+use std::ops::DerefMut;
 
 /// Helper to format BIP-329 LabelRefs into searchable strings
 fn format_ref_str(item_ref: &LabelRef) -> String {
     match item_ref {
         LabelRef::Txid(txid) => format!("txid:{}", txid),
-        LabelRef::Address(addr) => format!("addr:{}", addr),
+        LabelRef::Address(addr) => format!("addr:{}", addr.assume_checked_ref()),
         LabelRef::Output(op) => format!("output:{}", op),
         LabelRef::Input(op) => format!("input:{}", op),
         _ => item_ref.to_string(), // Fallback for pubkey/xpub
@@ -106,10 +108,21 @@ fn format_ref_str(item_ref: &LabelRef) -> String {
 
 /// Helper to safely extract a label string or return an em dash
 fn get_label_string(labels: &bip329::Labels, target_ref_str: &str) -> String {
-    labels.iter()
+    labels
+        .iter()
         .find(|l| format_ref_str(&l.ref_()) == target_ref_str)
         .and_then(|l| l.label().map(|s| s.to_string()))
         .unwrap_or_else(|| "—".to_string())
+}
+
+fn add_or_update_label(labels: &mut bip329::Labels, new_label: BipLabel) {
+    let target_ref = new_label.ref_();
+    let labels_vec = labels.deref_mut();
+
+    match labels_vec.iter_mut().find(|l| l.ref_() == target_ref) {
+        Some(existing) => *existing = new_label,
+        None => labels_vec.push(new_label),
+    }
 }
 
 #[cfg(feature = "compiler")]
@@ -178,6 +191,46 @@ pub fn handle_offline_wallet_subcommand(
                 }))?)
             }
         }
+        Label {
+            label_str,
+            address,
+            txid,
+            utxo,
+        } => {
+            let new_label = if let Some(addr) = address {
+                BipLabel::Address(AddressRecord {
+                    ref_: addr.into_unchecked(),
+                    label: Some(label_str.clone()),
+                })
+            } else if let Some(tx) = txid {
+                BipLabel::Transaction(TransactionRecord {
+                    ref_: tx,
+                    label: Some(label_str.clone()),
+                    origin: None,
+                })
+            } else if let Some(outpoint) = utxo {
+                BipLabel::Output(OutputRecord {
+                    ref_: outpoint,
+                    label: Some(label_str.clone()),
+                    spendable: false,
+                })
+            } else {
+                return Err(Error::Generic(
+                    "No target provided for the label".to_string(),
+                ));
+            };
+
+            add_or_update_label(labels, new_label);
+
+            if cli_opts.pretty {
+                Ok(format!("Successfully applied label '{}'", label_str))
+            } else {
+                Ok(serde_json::to_string_pretty(&json!({
+                    "message": "Label successfully applied",
+                    "label": label_str
+                }))?)
+            }
+        }
         Unspent => {
             let utxos = wallet.list_unspent().collect::<Vec<_>>();
             if cli_opts.pretty {
@@ -226,17 +279,23 @@ pub fn handle_offline_wallet_subcommand(
                         "Index".cell().bold(true),
                         "Block Height".cell().bold(true),
                         "Block Hash".cell().bold(true),
-                        "Label".cell().bold(true)
+                        "Label".cell().bold(true),
                     ])
                     .display()
                     .map_err(|e| Error::Generic(e.to_string()))?;
                 Ok(format!("{table}"))
             } else {
-                let utxos_json: Vec<_> = utxos.iter().map(|utxo| {
-                    let mut json_obj = serde_json::to_value(utxo).unwrap();
-                    json_obj["label"] = json!(get_label_string(labels, &format!("output:{}", utxo.outpoint)));
-                    json_obj
-                }).collect();
+                let utxos_json: Vec<_> = utxos
+                    .iter()
+                    .map(|utxo| {
+                        let mut json_obj = serde_json::to_value(utxo).unwrap();
+                        json_obj["label"] = json!(get_label_string(
+                            labels,
+                            &format!("output:{}", utxo.outpoint)
+                        ));
+                        json_obj
+                    })
+                    .collect();
                 Ok(serde_json::to_string_pretty(&utxos_json)?)
             }
         }
@@ -1308,13 +1367,16 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
             let datadir = cli_opts.datadir.clone();
             let home_dir = prepare_home_dir(datadir)?;
             let (wallet_opts, network) = load_wallet_config(&home_dir, &wallet_name)?;
-
             let database_path = prepare_wallet_db_dir(&home_dir, &wallet_name)?;
             let label_file_path = database_path.join("labels.jsonl");
 
             let mut labels = match bip329::Labels::try_from_file(&label_file_path) {
                 Ok(loaded_labels) => loaded_labels,
-                Err(bip329::error::ParseError::FileReadError(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => bip329::Labels::default(),
+                Err(bip329::error::ParseError::FileReadError(io_err))
+                    if io_err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    bip329::Labels::default()
+                }
                 Err(e) => return Err(Error::Generic(format!("Failed to load labels: {}", e))),
             };
 
@@ -1363,7 +1425,9 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     &mut labels,
                 )?
             };
-            labels.export_to_file(&label_file_path).map_err(|e| Error::Generic(format!("Failed to save labels: {}", e)))?;
+            labels
+                .export_to_file(&label_file_path)
+                .map_err(|e| Error::Generic(format!("Failed to save labels: {}", e)))?;
 
             Ok(result)
         }
@@ -1521,9 +1585,15 @@ async fn respond(
         ReplSubCommand::Wallet {
             subcommand: WalletSubCommand::OfflineWalletSubCommand(offline_subcommand),
         } => {
-            let value =
-                handle_offline_wallet_subcommand(wallet, wallet_opts, cli_opts, offline_subcommand)
-                    .map_err(|e| e.to_string())?;
+            let mut labels = bip329::Labels::default();
+            let value = handle_offline_wallet_subcommand(
+                wallet,
+                wallet_opts,
+                cli_opts,
+                offline_subcommand,
+                &mut labels,
+            )
+            .map_err(|e| e.to_string())?;
             Some(value)
         }
         ReplSubCommand::Wallet {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -103,6 +103,7 @@ pub fn handle_offline_wallet_subcommand(
     wallet_opts: &WalletOpts,
     cli_opts: &CliOpts,
     offline_subcommand: OfflineWalletSubCommand,
+    labels: &mut bip329::Labels,
 ) -> Result<String, Error> {
     match offline_subcommand {
         NewAddress => {
@@ -1273,6 +1274,15 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
             let home_dir = prepare_home_dir(datadir)?;
             let (wallet_opts, network) = load_wallet_config(&home_dir, &wallet_name)?;
 
+            let database_path = prepare_wallet_db_dir(&home_dir, &wallet_name)?;
+            let label_file_path = database_path.join("labels.jsonl");
+
+            let mut labels = match bip329::Labels::try_from_file(&label_file_path) {
+                Ok(loaded_labels) => loaded_labels,
+                Err(bip329::error::ParseError::FileReadError(io_err)) if io_err.kind() == std::io::ErrorKind::NotFound => bip329::Labels::default(),
+                Err(e) => return Err(Error::Generic(format!("Failed to load labels: {}", e))),
+            };
+
             #[cfg(any(feature = "sqlite", feature = "redb"))]
             let result = {
                 let mut persister: Persister = match &wallet_opts.database_type {
@@ -1302,6 +1312,7 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     &wallet_opts,
                     &cli_opts,
                     offline_subcommand.clone(),
+                    &mut labels,
                 )?;
                 wallet.persist(&mut persister)?;
                 result
@@ -1314,8 +1325,11 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                     &wallet_opts,
                     &cli_opts,
                     offline_subcommand.clone(),
+                    &mut labels,
                 )?
             };
+            labels.export_to_file(&label_file_path).map_err(|e| Error::Generic(format!("Failed to save labels: {}", e)))?;
+            
             Ok(result)
         }
         CliSubCommand::Wallet {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -98,10 +98,10 @@ use std::ops::DerefMut;
 /// Helper to format BIP-329 LabelRefs into searchable strings
 fn format_ref_str(item_ref: &LabelRef) -> String {
     match item_ref {
-        LabelRef::Txid(txid) => format!("txid:{}", txid),
+        LabelRef::Txid(txid) => format!("txid:{txid}"),
         LabelRef::Address(addr) => format!("addr:{}", addr.assume_checked_ref()),
-        LabelRef::Output(op) => format!("output:{}", op),
-        LabelRef::Input(op) => format!("input:{}", op),
+        LabelRef::Output(op) => format!("output:{op}"),
+        LabelRef::Input(op) => format!("input:{op}"),
         _ => item_ref.to_string(), // Fallback for pubkey/xpub
     }
 }
@@ -223,7 +223,7 @@ pub fn handle_offline_wallet_subcommand(
             add_or_update_label(labels, new_label);
 
             if cli_opts.pretty {
-                Ok(format!("Successfully applied label '{}'", label_str))
+                Ok(format!("Successfully applied label '{label_str}'"))
             } else {
                 Ok(serde_json::to_string_pretty(&json!({
                     "message": "Label successfully applied",
@@ -323,7 +323,7 @@ pub fn handle_offline_wallet_subcommand(
                     .collect::<Vec<_>>();
                 let mut rows: Vec<Vec<CellStruct>> = vec![];
                 for (txid, version, is_rbf, input_count, output_count, total_value) in txns {
-                    let label_str = get_label_string(labels, &format!("txid:{}", txid));
+                    let label_str = get_label_string(labels, &format!("txid:{txid}"));
                     rows.push(vec![
                         txid.cell(),
                         version.to_string().cell().justify(Justify::Right),
@@ -360,7 +360,7 @@ pub fn handle_offline_wallet_subcommand(
                             "is_rbf": tx.tx_node.is_explicitly_rbf(),
                             "inputs": tx.tx_node.input,
                             "outputs": tx.tx_node.output,
-                            "label": get_label_string(labels, &format!("txid:{}", txid)),
+                            "label": get_label_string(labels, &format!("txid:{txid}")),
                         })
                     })
                     .collect();
@@ -1377,7 +1377,7 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                 {
                     bip329::Labels::default()
                 }
-                Err(e) => return Err(Error::Generic(format!("Failed to load labels: {}", e))),
+                Err(e) => return Err(Error::Generic(format!("Failed to load labels: {e}"))),
             };
 
             #[cfg(any(feature = "sqlite", feature = "redb"))]
@@ -1427,7 +1427,7 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
             };
             labels
                 .export_to_file(&label_file_path)
-                .map_err(|e| Error::Generic(format!("Failed to save labels: {}", e)))?;
+                .map_err(|e| Error::Generic(format!("Failed to save labels: {e}")))?;
 
             Ok(result)
         }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -91,6 +91,27 @@ use {
     bdk_wallet::chain::{BlockId, CanonicalizationParams, CheckPoint},
 };
 
+use bip329::LabelRef;
+
+/// Helper to format BIP-329 LabelRefs into searchable strings
+fn format_ref_str(item_ref: &LabelRef) -> String {
+    match item_ref {
+        LabelRef::Txid(txid) => format!("txid:{}", txid),
+        LabelRef::Address(addr) => format!("addr:{}", addr),
+        LabelRef::Output(op) => format!("output:{}", op),
+        LabelRef::Input(op) => format!("input:{}", op),
+        _ => item_ref.to_string(), // Fallback for pubkey/xpub
+    }
+}
+
+/// Helper to safely extract a label string or return an em dash
+fn get_label_string(labels: &bip329::Labels, target_ref_str: &str) -> String {
+    labels.iter()
+        .find(|l| format_ref_str(&l.ref_()) == target_ref_str)
+        .and_then(|l| l.label().map(|s| s.to_string()))
+        .unwrap_or_else(|| "—".to_string())
+}
+
 #[cfg(feature = "compiler")]
 const NUMS_UNSPENDABLE_KEY_HEX: &str =
     "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
@@ -173,6 +194,8 @@ pub fn handle_offline_wallet_subcommand(
                         ChainPosition::Unconfirmed { .. } => "Unconfirmed".to_string(),
                     };
 
+                    let label_str = get_label_string(labels, &format!("output:{}", utxo.outpoint));
+
                     rows.push(vec![
                         shorten(utxo.outpoint, 8, 10).cell(),
                         utxo.txout
@@ -189,6 +212,7 @@ pub fn handle_offline_wallet_subcommand(
                         utxo.derivation_index.cell(),
                         height.to_string().cell().justify(Justify::Right),
                         shorten(block_hash, 8, 8).cell().justify(Justify::Right),
+                        label_str.cell(),
                     ]);
                 }
                 let table = rows
@@ -202,12 +226,18 @@ pub fn handle_offline_wallet_subcommand(
                         "Index".cell().bold(true),
                         "Block Height".cell().bold(true),
                         "Block Hash".cell().bold(true),
+                        "Label".cell().bold(true)
                     ])
                     .display()
                     .map_err(|e| Error::Generic(e.to_string()))?;
                 Ok(format!("{table}"))
             } else {
-                Ok(serde_json::to_string_pretty(&utxos)?)
+                let utxos_json: Vec<_> = utxos.iter().map(|utxo| {
+                    let mut json_obj = serde_json::to_value(utxo).unwrap();
+                    json_obj["label"] = json!(get_label_string(labels, &format!("output:{}", utxo.outpoint)));
+                    json_obj
+                }).collect();
+                Ok(serde_json::to_string_pretty(&utxos_json)?)
             }
         }
         Transactions => {
@@ -234,6 +264,7 @@ pub fn handle_offline_wallet_subcommand(
                     .collect::<Vec<_>>();
                 let mut rows: Vec<Vec<CellStruct>> = vec![];
                 for (txid, version, is_rbf, input_count, output_count, total_value) in txns {
+                    let label_str = get_label_string(labels, &format!("txid:{}", txid));
                     rows.push(vec![
                         txid.cell(),
                         version.to_string().cell().justify(Justify::Right),
@@ -241,6 +272,7 @@ pub fn handle_offline_wallet_subcommand(
                         input_count.to_string().cell().justify(Justify::Right),
                         output_count.to_string().cell().justify(Justify::Right),
                         total_value.to_string().cell().justify(Justify::Right),
+                        label_str.cell(),
                     ]);
                 }
                 let table = rows
@@ -252,6 +284,7 @@ pub fn handle_offline_wallet_subcommand(
                         "Input Count".cell().bold(true),
                         "Output Count".cell().bold(true),
                         "Total Value (sat)".cell().bold(true),
+                        "Label".cell().bold(true),
                     ])
                     .display()
                     .map_err(|e| Error::Generic(e.to_string()))?;
@@ -259,14 +292,16 @@ pub fn handle_offline_wallet_subcommand(
             } else {
                 let txns: Vec<_> = transactions
                     .map(|tx| {
+                        let txid = tx.tx_node.txid.to_string();
                         json!({
-                            "txid": tx.tx_node.txid,
+                            "txid": txid,
                             "is_coinbase": tx.tx_node.is_coinbase(),
                             "wtxid": tx.tx_node.compute_wtxid(),
                             "version": tx.tx_node.version,
                             "is_rbf": tx.tx_node.is_explicitly_rbf(),
                             "inputs": tx.tx_node.input,
                             "outputs": tx.tx_node.output,
+                            "label": get_label_string(labels, &format!("txid:{}", txid)),
                         })
                     })
                     .collect();
@@ -1329,7 +1364,7 @@ pub(crate) async fn handle_command(cli_opts: CliOpts) -> Result<String, Error> {
                 )?
             };
             labels.export_to_file(&label_file_path).map_err(|e| Error::Generic(format!("Failed to save labels: {}", e)))?;
-            
+
             Ok(result)
         }
         CliSubCommand::Wallet {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub(crate) fn parse_proxy_auth(s: &str) -> Result<(String, String), Error> {
 
 /// Parse a txid argument from cli input.
 pub(crate) fn parse_txid(s: &str) -> Result<Txid, Error> {
-    Ok(Txid::from_str(s).map_err(|e| Error::Generic(e.to_string()))?)
+    Txid::from_str(s).map_err(|e| Error::Generic(e.to_string()))
 }
 
 /// Parse a outpoint (Txid:Vout) argument from cli input.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,7 +50,7 @@ use bdk_wallet::{PersistedWallet, WalletPersister};
 
 use bdk_wallet::bip39::{Language, Mnemonic};
 use bdk_wallet::bitcoin::{
-    Address, Network, OutPoint, ScriptBuf, bip32::Xpriv, secp256k1::Secp256k1,
+    Address, Network, OutPoint, ScriptBuf, Txid, bip32::Xpriv, secp256k1::Secp256k1,
 };
 use bdk_wallet::descriptor::Segwitv0;
 use bdk_wallet::keys::{GeneratableKey, GeneratedKey, bip39::WordCount};
@@ -82,6 +82,11 @@ pub(crate) fn parse_proxy_auth(s: &str) -> Result<(String, String), Error> {
     let passwd = parts[1].to_string();
 
     Ok((user, passwd))
+}
+
+/// Parse a txid argument from cli input.
+pub(crate) fn parse_txid(s: &str) -> Result<Txid, Error> {
+    Ok(Txid::from_str(s).map_err(|e| Error::Generic(e.to_string()))?)
 }
 
 /// Parse a outpoint (Txid:Vout) argument from cli input.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being added and/or fixed -->

This PR adds BIP-329 wallet label support to `bdk-cli`, to fix #184. It uses the [`[bip329]`](https://github.com/bitcoinppl/bip329) crate to manage label data, persists it in a separate `labels.jsonl` file within the wallet's data directory (e.g. `~/.bdk-bitcoin/<wallet_name>/labels.jsonl`), and keeps it decoupled from the wallet's SQLite/redb database. It also exports and imports label files.

This PR includes the following functionality:

- **Set labels**: It uses a new `label` offline subcommand to attach a human-readable label to either a transaction ID, address, or UTXO (outpoint).
- **Persist labels**: It ensures that Labels are loaded from disk at the start of every offline wallet command and saved back after the command completes, so they survive across sessions.
- **Display labels**: The `unspent` and `transactions` commands now include a `Label` column in both `--pretty` table output and standard JSON output, showing the stored label or an em dash if none exists.
- **Import labels**: The `import_labels` subcommand merges labels from an external BIP-329 JSONL file into the wallet's current label state. If a label for the same item already exists, it is overwritten by the imported one.
- **Export labels**: The `export_labels` subcommand writes the wallet's current label state to a user-specified BIP-329 JSONL file, suitable for backup or use in other BIP-329 compliant wallets.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

- Labels are stored in a separate `labels.jsonl` file rather than inside the wallet database. This keeps the label format portable and interoperable with other BIP-329 compliant wallets.
- The `Label` import from `bip329` is aliased as `BipLabel` in `handlers.rs` to avoid a name clash with the `OfflineWalletSubCommand::Label` variant brought into scope via `use crate::commands::OfflineWalletSubCommand::*`.
- The `import_labels` command uses the existing `add_or_update_label` helper to merge incoming labels one at a time, new label references are inserted, and existing label references are overwritten by the imported value.
- The `export_labels` command writes to a user-specified path, which is independent of the wallet's internal `labels.jsonl` file. The internal file is always managed automatically by the save-on-exit mechanism, so the two files remain separate.


## Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Added
- New `label` subcommand to `OfflineWalletSubCommand` for tagging transactions, addresses, and UTXOs with human-readable labels.
- New `import_labels` subcommand to merge labels from an external BIP-329 JSONL file into the wallet's current label state.
- New `export_labels` subcommand to back up the wallet's current label state to a user-specified BIP-329 JSONL file.
- BIP-329 compliant label persistence via a `labels.jsonl` file in the wallet data directory.
- `Label` column in `unspent` and `transactions` output (both `--pretty` and JSON).
- `parse_txid` helper in `utils.rs`.
- `bip329 = "0.4.0"` dependency in `Cargo.toml`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR