### PR TITLE
fix: fix RUSTSEC-2026-0097 for rand 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls 0.23.36",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",


### PR DESCRIPTION
Fixes #269

Update transitive dependency `rand` from 0.9.2 to 0.9.3 via `cargo update -p rand@0.9.2` to resolve RUSTSEC-2026-0097.

Note: #268 (`rand 0.8.5` via `secp256k1` and others) remains unaffected by this change and needs to be fixed upstream.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
