### PR TITLE
chore(rustsec): update rustls-webpki 0.103.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2344,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Fixes #276 
Fixes #277 
Fixes #280

---
### Description

Update transitive dependency `rustls-webpki` from `0.103.10` to `0.103.13` via:

```
cargo update -p rustls-webpki@0.103.10 --precise 0.103.13
```

### Notes to the reviewers

This does not fix `rustls-webpki 0.101.7`, pulled in via `minreq`:

```
-> % cargo audit
...
Dependency tree:
rustls-webpki 0.101.7
├── rustls 0.21.12
│   └── minreq 2.14.1
│       ├── jsonrpc 0.18.0
│       │   └── bitcoincore-rpc 0.19.0
│       │       └── bdk_bitcoind_rpc 0.21.0
│       │           └── bdk-cli 3.0.0
│       └── esplora-client 0.12.1
│           └── bdk_esplora 0.22.1
│               └── bdk-cli 3.0.0
└── minreq 2.14.1
...
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
