### PR TITLE
fix(create_tx): enforce single recipient for send_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog info is also documented on the [GitHub releases](https://github.com/bi
 page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
 
 ## [Unreleased]
+ - Fixed `create_tx --send_all` to reject multiple recipients instead of silently using only the first one
 
 ## [3.0.0]
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -540,7 +540,13 @@ pub fn handle_offline_wallet_subcommand(
             let mut tx_builder = wallet.build_tx();
 
             if send_all {
-                tx_builder.drain_wallet().drain_to(recipients[0].0.clone());
+                if recipients.len() == 1 {
+                    tx_builder.drain_wallet().drain_to(recipients[0].0.clone());
+                } else {
+                    return Err(Error::Generic(
+                        "Wallet can only be drained to a single output".to_string(),
+                    ));
+                }
             } else {
                 let recipients = recipients
                     .into_iter()


### PR DESCRIPTION
Closes #290

### Description

Previously, passing multiple `--to` arguments with `--send_all` would silently drain the wallet to only the first recipient, ignoring the rest. This was inconsistent with the silent-payments `create_tx`, which already validates the recipient count.

Now returns an error unless exactly one recipient is provided.

### Notes to the reviewers

- The fix mirrors the validation logic already present in the silent-payments `create_tx` branch of the same file, so behavior is now consistent between the two code paths.

## Changelog notice
- Fixed create_tx --send_all to reject multiple recipients instead of silently using only the first one

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR