### PR TITLE
rename `bip322` feature to `message_signer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
 
 ## [Unreleased]
  - Fixed `create_tx --send_all` to reject multiple recipients instead of silently using only the first one
+ - Renamed the `bip322` feature to `message_signer`
 
 ## [3.0.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "bdk_redb",
  "bdk_sp",
  "bdk_testenv",
- "bdk_wallet",
+ "bdk_wallet 2.4.0",
  "bitcoin-payment-instructions",
  "clap",
  "clap_complete",
@@ -342,13 +342,23 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346c1d502ee4613cf2201db9c3b93a2317772d8eaa372114f34bf5f374be94fd"
 dependencies = [
- "bdk_wallet",
+ "bdk_wallet 2.4.0",
  "bip157",
 ]
 
 [[package]]
 name = "bdk_message_signer"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e0c999b3dcc448ceb6337658c363df3197bbed987b663810497bd9c20ea4ef"
+dependencies = [
+ "bdk_wallet 3.1.0",
+ "bitcoin",
+]
+
+[[package]]
+name = "bdk_redb"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e0c999b3dcc448ceb6337658c363df3197bbed987b663810497bd9c20ea4ef"
 dependencies = [
@@ -363,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ac8b88c9594c615fcb5b763e7afa16937e94f7a7f5ca334bf59a7fee69fea1"
 dependencies = [
  "bdk_chain",
- "bdk_wallet",
+ "bdk_wallet 2.4.0",
  "ciborium",
  "redb",
  "thiserror 2.0.18",
@@ -395,6 +405,20 @@ checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
 dependencies = [
  "bdk_chain",
  "bip39",
+ "bitcoin",
+ "miniscript",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bdk_wallet"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
+dependencies = [
+ "bdk_chain",
  "bitcoin",
  "miniscript",
  "rand_core 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "bdk_redb",
  "bdk_sp",
  "bdk_testenv",
- "bdk_wallet 2.4.0",
+ "bdk_wallet",
  "bitcoin-payment-instructions",
  "clap",
  "clap_complete",
@@ -342,23 +342,13 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346c1d502ee4613cf2201db9c3b93a2317772d8eaa372114f34bf5f374be94fd"
 dependencies = [
- "bdk_wallet 2.4.0",
+ "bdk_wallet",
  "bip157",
 ]
 
 [[package]]
 name = "bdk_message_signer"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e0c999b3dcc448ceb6337658c363df3197bbed987b663810497bd9c20ea4ef"
-dependencies = [
- "bdk_wallet 3.1.0",
- "bitcoin",
-]
-
-[[package]]
-name = "bdk_redb"
-version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e0c999b3dcc448ceb6337658c363df3197bbed987b663810497bd9c20ea4ef"
 dependencies = [
@@ -373,7 +363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ac8b88c9594c615fcb5b763e7afa16937e94f7a7f5ca334bf59a7fee69fea1"
 dependencies = [
  "bdk_chain",
- "bdk_wallet 2.4.0",
+ "bdk_wallet",
  "ciborium",
  "redb",
  "thiserror 2.0.18",
@@ -405,20 +395,6 @@ checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
 dependencies = [
  "bdk_chain",
  "bip39",
- "bitcoin",
- "miniscript",
- "rand_core 0.6.4",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "bdk_wallet"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
-dependencies = [
- "bdk_chain",
  "bitcoin",
  "miniscript",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ dns_payment = ["bitcoin-payment-instructions"]
 
 # Internal features
 _payjoin-dependencies = ["payjoin", "reqwest", "url", "sqlite"]
-bip322 = ["bdk_message_signer"]
+message_signer = ["bdk_message_signer"]
 
 # Use this to consensus verify transactions at sync time
 verify = []

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -13,7 +13,7 @@
 //! All subcommands are defined in the below enums.
 
 #![allow(clippy::large_enum_variant)]
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 use crate::handlers::offline::{SignMessageCommand, VerifyMessageCommand};
 use crate::handlers::{
     config::{ListWalletsCommand, SaveConfigCommand},
@@ -362,10 +362,10 @@ pub enum OfflineWalletSubCommand {
     /// Combines multiple PSBTs into one.
     CombinePsbt(CombinePsbtCommand),
     /// Sign a message using BIP322
-    #[cfg(feature = "bip322")]
+    #[cfg(feature = "message_signer")]
     SignMessage(SignMessageCommand),
     /// Verify a BIP322 signature
-    #[cfg(feature = "bip322")]
+    #[cfg(feature = "message_signer")]
     VerifyMessage(VerifyMessageCommand),
     /// Lock UTXO(s) so they're excluded from coin selection.
     LockUtxo(LockUtxoCommand),

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,9 +155,10 @@ pub enum BDKCliError {
     #[cfg(feature = "payjoin")]
     #[error("Payjoin database error: {0}")]
     PayjoinDb(#[from] crate::handlers::payjoin::db::Error),
-    #[cfg(feature = "bip322")]
+
+    #[cfg(feature = "message_signer")]
     #[error("BIP-322 error: {0}")]
-    Bip322Error(#[from] bdk_message_signer::error::Error),
+    MessageSignerError(#[from] bdk_message_signer::error::Error),
 }
 
 impl From<ExtractTxError> for BDKCliError {

--- a/src/handlers/offline.rs
+++ b/src/handlers/offline.rs
@@ -28,11 +28,11 @@ use {
     bdk_wallet::keys::{DescriptorPublicKey, DescriptorSecretKey, SinglePubKey},
     std::collections::HashMap,
 };
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 use {
     crate::utils::parse_signature_format,
     crate::utils::types::MessageResult,
-    bdk_message_signer::{MessageProof, MessageSigner},
+    bdk_message_signer::{MessageSigner, MessageProof},
 };
 
 impl OfflineWalletSubCommand {
@@ -73,11 +73,11 @@ impl OfflineWalletSubCommand {
             Self::CombinePsbt(combine_psbt_command) => combine_psbt_command
                 .execute(ctx)?
                 .write_out(std::io::stdout()),
-            #[cfg(feature = "bip322")]
+            #[cfg(feature = "message_signer")]
             Self::SignMessage(sign_message_command) => sign_message_command
                 .execute(ctx)?
                 .write_out(std::io::stdout()),
-            #[cfg(feature = "bip322")]
+            #[cfg(feature = "message_signer")]
             Self::VerifyMessage(verify_message_command) => verify_message_command
                 .execute(ctx)?
                 .write_out(std::io::stdout()),
@@ -773,7 +773,7 @@ impl AppCommand<AppContext<OfflineOperations<'_>>> for CombinePsbtCommand {
     }
 }
 
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 #[derive(Debug, Parser, Clone, PartialEq)]
 pub struct SignMessageCommand {
     /// The message to sign
@@ -793,7 +793,7 @@ pub struct SignMessageCommand {
     pub utxos: Option<Vec<OutPoint>>,
 }
 
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 impl AppCommand<AppContext<OfflineOperations<'_>>> for SignMessageCommand {
     type Output = MessageResult;
 
@@ -823,7 +823,7 @@ impl AppCommand<AppContext<OfflineOperations<'_>>> for SignMessageCommand {
     }
 }
 
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 #[derive(Debug, Parser, Clone, PartialEq)]
 pub struct VerifyMessageCommand {
     /// The signature proof to verify
@@ -839,7 +839,7 @@ pub struct VerifyMessageCommand {
     pub address: String,
 }
 
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 impl AppCommand<AppContext<OfflineOperations<'_>>> for VerifyMessageCommand {
     type Output = MessageResult;
 

--- a/src/handlers/offline.rs
+++ b/src/handlers/offline.rs
@@ -32,7 +32,7 @@ use {
 use {
     crate::utils::parse_signature_format,
     crate::utils::types::MessageResult,
-    bdk_message_signer::{MessageSigner, MessageProof},
+    bdk_message_signer::{MessageProof, MessageSigner},
 };
 
 impl OfflineWalletSubCommand {

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -1,8 +1,8 @@
 use crate::{commands::WalletOpts, config::WalletConfig, error::BDKCliError as Error};
-#[cfg(feature = "message_signer")]
-use bdk_message_signer::SignatureFormat;
 #[cfg(feature = "cbf")]
 use bdk_kyoto::{Info, Receiver, UnboundedReceiver, Warning};
+#[cfg(feature = "message_signer")]
+use bdk_message_signer::SignatureFormat;
 #[cfg(feature = "silent-payments")]
 use bdk_sp::encoding::SilentPaymentCode;
 use bdk_wallet::bitcoin::{Address, Network, OutPoint, ScriptBuf};

--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -1,8 +1,8 @@
 use crate::{commands::WalletOpts, config::WalletConfig, error::BDKCliError as Error};
+#[cfg(feature = "message_signer")]
+use bdk_message_signer::SignatureFormat;
 #[cfg(feature = "cbf")]
 use bdk_kyoto::{Info, Receiver, UnboundedReceiver, Warning};
-#[cfg(feature = "bip322")]
-use bdk_message_signer::SignatureFormat;
 #[cfg(feature = "silent-payments")]
 use bdk_sp::encoding::SilentPaymentCode;
 use bdk_wallet::bitcoin::{Address, Network, OutPoint, ScriptBuf};
@@ -198,7 +198,7 @@ pub(crate) fn parse_sp_code_value_pairs(s: &str) -> Result<(SilentPaymentCode, u
 }
 
 /// Function to parse the signature format from a string
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 pub(crate) fn parse_signature_format(format_str: &str) -> Result<SignatureFormat, Error> {
     match format_str.to_lowercase().as_str() {
         "legacy" => Ok(SignatureFormat::Legacy),
@@ -232,10 +232,10 @@ pub fn command_requires_db(command: &OfflineWalletSubCommand) -> bool {
         | OfflineWalletSubCommand::FinalizePsbt(_)
         | OfflineWalletSubCommand::CombinePsbt(_) => false,
 
-        #[cfg(feature = "bip322")]
+        #[cfg(feature = "message_signer")]
         OfflineWalletSubCommand::SignMessage(_) => true,
 
-        #[cfg(feature = "bip322")]
+        #[cfg(feature = "message_signer")]
         OfflineWalletSubCommand::VerifyMessage(_) => true,
         #[cfg(feature = "silent-payments")]
         OfflineWalletSubCommand::CreateSpTx(_) => true,

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -110,7 +110,7 @@ pub struct KeychainPair<T> {
     pub internal: T,
 }
 
-#[cfg(feature = "bip322")]
+#[cfg(feature = "message_signer")]
 #[derive(Serialize, Debug, Default)]
 pub struct MessageResult {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/integration/offline.rs
+++ b/tests/integration/offline.rs
@@ -151,7 +151,7 @@ mod test_offline {
         .stderr(predicate::str::contains("Invalid"));
     }
 
-    #[cfg(feature = "bip322")]
+    #[cfg(feature = "message_signer")]
     #[test]
     fn test_sign_message_and_verify_message() {
         let (cli, mut cmd_init) = setup_wallet_config();
@@ -216,7 +216,7 @@ mod test_offline {
         .stdout(predicate::str::contains("\"valid\": true"));
     }
 
-    #[cfg(feature = "bip322")]
+    #[cfg(feature = "message_signer")]
     #[test]
     fn test_verify_message_rejects_tampered_message() {
         let (cli, mut cmd_init) = setup_wallet_config();

--- a/tests/integration/online.rs
+++ b/tests/integration/online.rs
@@ -814,7 +814,7 @@ mod test_online {
         }
     }
 
-    #[cfg(feature = "bip322")]
+    #[cfg(feature = "message_signer")]
     #[test]
     fn test_verify_message_proof_of_funds_uses_persisted_utxos() {
         let env = TestEnv::new().expect("Failed to start bdk_testenv");


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This PR renames the `bip322` to `message_signer`.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

## Changelog notice

- Rename bip322 feature to message_signer
<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
