### PR TITLE
chore: remove unused tap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex 1.3.0",
- "tap",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3344,12 +3343,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.20"
 toml = "1.1.0"
 serde= {version = "1.0", features = ["derive"]}
-tap = "1.0.1"
 
 # Optional dependencies
 bdk_bitcoind_rpc = { version = "0.22.0", features = ["std"], optional = true }


### PR DESCRIPTION
Closes #314

### Description

Removes the unused `tap` dependency, per @tvpeter's [decision](https://github.com/bitcoindevkit/bdk-cli/issues/314#issuecomment-5311773042).

## Changelog notice

- Removed the unused `tap` dependency

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
