### PR TITLE
fix(compile): compile only for the requested script context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
 
 ## [Unreleased]
 
+- Fixed `compile` rejecting policies that are valid for the requested script type
+
 ## [4.0.0]
 
 - Added persistance to existing async payjoin integration

--- a/src/handlers/descriptor.rs
+++ b/src/handlers/descriptor.rs
@@ -20,7 +20,7 @@ use {
             key::{Parity, rand},
             secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey},
         },
-        miniscript::{Descriptor, Miniscript, descriptor::TapTree, policy::Concrete},
+        miniscript::{Descriptor, descriptor::TapTree, policy::Concrete},
     },
     std::{str::FromStr, sync::Arc},
 };
@@ -83,22 +83,14 @@ impl AppCommand<AppContext<Init>> for CompileCommand {
         let policy: Concrete<String> = Concrete::from_str(&self.policy)
             .map_err(|e| Error::Generic(format!("Invalid policy: {e}")))?;
 
-        let legacy_policy: Miniscript<String, bdk_wallet::miniscript::Legacy> = policy
-            .compile()
-            .map_err(|e| Error::Generic(e.to_string()))?;
-        let segwit_policy: Miniscript<String, bdk_wallet::miniscript::Segwitv0> = policy
-            .compile()
-            .map_err(|e| Error::Generic(e.to_string()))?;
-        let taproot_policy: Miniscript<String, bdk_wallet::miniscript::Tap> = policy
-            .compile()
-            .map_err(|e| Error::Generic(e.to_string()))?;
-
         let mut r = None;
 
+        // Compile per branch, not once up front: the contexts have different script
+        // limits, and the narrowest one would reject policies valid for the requested type.
         let descriptor = match self.script_type.as_str() {
-            "sh" => Descriptor::new_sh(legacy_policy),
-            "wsh" => Descriptor::new_wsh(segwit_policy),
-            "sh-wsh" => Descriptor::new_sh_wsh(segwit_policy),
+            "sh" => Descriptor::new_sh(policy.compile()?),
+            "wsh" => Descriptor::new_wsh(policy.compile()?),
+            "sh-wsh" => Descriptor::new_sh_wsh(policy.compile()?),
             "tr" => {
                 // Use a randomized unspendable internal key (H + rG) instead of a fixed NUMS
                 // point. This improves privacy by preventing observers from determining whether
@@ -118,7 +110,7 @@ impl AppCommand<AppContext<Init>> for CompileCommand {
                         .map_err(|e| Error::Generic(format!("Failed to tweak NUMS key: {e}")))?;
                 let (xonly_internal_key, _) = internal_key_point.x_only_public_key();
 
-                let tree = TapTree::Leaf(Arc::new(taproot_policy));
+                let tree = TapTree::Leaf(Arc::new(policy.compile()?));
                 Descriptor::new_tr(xonly_internal_key.to_string(), Some(tree))
             }
             _ => {

--- a/tests/integration/init.rs
+++ b/tests/integration/init.rs
@@ -203,6 +203,26 @@ mod test_compile {
             .stdout(predicate::str::contains("wsh("));
     }
 
+    /// A policy can be valid for taproot and still exceed the limits of the
+    /// legacy context, whose 520-byte redeemScript cap does not apply to it.
+    /// Compiling for `tr` must not be blocked by the other contexts.
+    #[test]
+    fn test_compile_taproot_policy_beyond_legacy_limits() {
+        let temp_dir = TempDir::new().unwrap();
+        let cli = BdkCli::new("testnet", Some(temp_dir.path().to_path_buf()));
+
+        let keys = (1..=20)
+            .map(|i| format!("pk(K{i:02})"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let policy = format!("thresh(2,{keys})");
+
+        cli.cmd("compile", &[&policy, "--type", "tr"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("tr("));
+    }
+
     #[test]
     fn test_compile_invalid_policy() {
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
The policy is compiled for all three script contexts one after another, before `--type` is looked at, and any of those failing aborts the command. So a policy that is valid for the type you asked for is rejected because it is invalid for one of the other two.

Here a 9-of-16 multisig is compiled with `--type tr` and fails on the legacy context: `CHECKMULTISIG` takes at most 15 keys, and what the compiler falls back to goes past [`MAX_SCRIPT_ELEMENT_SIZE`](https://github.com/rust-bitcoin/rust-miniscript/blob/miniscript-12.3.7/src/miniscript/limits.rs#L22), the 520-byte consensus limit. Taproot has no such limit.

```
$ cargo run --all-features -- compile "thresh(9,pk(a),pk(b),pk(c),pk(d),pk(e),pk(f),pk(g),pk(h),pk(i),pk(j),pk(k),pk(l),pk(m),pk(n),pk(o),pk(p))" --type tr

thread 'main' panicked at miniscript-12.3.7/src/policy/compiler.rs:506:52:
Terminal creation must always succeed: ContextError(MaxRedeemScriptSizeExceeded)
```

The fix moves the compilation into the matching branch, so only the requested context is compiled.

## Changelog notice

- Fixed `compile` rejecting policies that are valid for the requested script type

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
