### PR TITLE
Refractor WalletRuntime load to Combine wallet DB dir setup and config loading into one function

### DIFF
--- a/src/utils/common.rs
+++ b/src/utils/common.rs
@@ -112,22 +112,6 @@ pub(crate) fn prepare_home_dir(home_path: Option<PathBuf>) -> Result<PathBuf, Er
     Ok(dir)
 }
 
-/// Prepare wallet database directory.
-#[allow(dead_code)]
-pub(crate) fn prepare_wallet_db_dir(
-    home_path: &Path,
-    wallet_name: &str,
-) -> Result<std::path::PathBuf, Error> {
-    let mut dir = home_path.to_owned();
-    dir.push(wallet_name);
-
-    if !dir.exists() {
-        std::fs::create_dir(&dir).map_err(|e| Error::Generic(e.to_string()))?;
-    }
-
-    Ok(dir)
-}
-
 pub fn is_mnemonic(s: &str) -> bool {
     let word_count = s.split_whitespace().count();
     (12..=24).contains(&word_count) && s.chars().all(|c| c.is_alphanumeric() || c.is_whitespace())
@@ -154,11 +138,19 @@ pub async fn trace_logger(
     }
 }
 
-pub fn load_wallet_config(
-    home_dir: &Path,
+/// Prepare wallet database directory and config.
+pub fn prepare_wallet_db_dir_and_config(
+    home_path: &Path,
     wallet_name: &str,
-) -> Result<(WalletOpts, Network), Error> {
-    let config = WalletConfig::load(home_dir)?.ok_or(Error::Generic(format!(
+) -> Result<(std::path::PathBuf, WalletOpts, Network), Error> {
+    let mut dir = home_path.to_owned();
+    dir.push(wallet_name);
+
+    if !dir.exists() {
+        std::fs::create_dir(&dir).map_err(|e| Error::Generic(e.to_string()))?;
+    }
+
+    let config = WalletConfig::load(home_path)?.ok_or(Error::Generic(format!(
         "No config found for wallet {wallet_name}",
     )))?;
 
@@ -173,7 +165,7 @@ pub fn load_wallet_config(
     let network = Network::from_str(&wallet_config.network)
         .map_err(|_| Error::Generic("Invalid network in config".to_string()))?;
 
-    Ok((wallet_opts, network))
+    Ok((dir, wallet_opts, network))
 }
 
 #[cfg(feature = "silent-payments")]

--- a/src/utils/runtime.rs
+++ b/src/utils/runtime.rs
@@ -7,9 +7,7 @@ use std::{
 };
 
 use crate::{
-    error::BDKCliError as Error,
-    persister::new_wallet,
-    utils::{load_wallet_config, prepare_wallet_db_dir},
+    error::BDKCliError as Error, persister::new_wallet, utils::prepare_wallet_db_dir_and_config,
 };
 #[cfg(any(feature = "sqlite", feature = "redb"))]
 use {
@@ -76,9 +74,8 @@ pub struct WalletRuntime {
 
 impl WalletRuntime {
     pub fn load(home_dir: &Path, wallet_name: &str) -> Result<Self, Error> {
-        let (wallet_opts, network) = load_wallet_config(home_dir, wallet_name)?;
-
-        let database_path = prepare_wallet_db_dir(home_dir, wallet_name)?;
+        let (database_path, wallet_opts, network) =
+            prepare_wallet_db_dir_and_config(home_dir, wallet_name)?;
 
         Ok(Self {
             wallet_name: wallet_name.to_string(),


### PR DESCRIPTION
### Description

Merges `prepare_wallet_db_dir` and `load_wallet_config` into a single `prepare_wallet_db_dir_and_config` function that returns the database path alongside WalletOpts and Network.

The two functions were always called together in WalletRuntime::load, so combining them removes the duplication and simplifies the call site.

### Notes to the reviewers

The main reason for this change is because the two functions merged were single-use.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

Thank you.