### PR TITLE
Refractor runtime persister to error out when not persisted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex 1.3.0",
- "tap",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3344,12 +3343,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.20"
 toml = "1.1.0"
 serde= {version = "1.0", features = ["derive"]}
-tap = "1.0.1"
 
 # Optional dependencies
 bdk_bitcoind_rpc = { version = "0.22.0", features = ["std"], optional = true }

--- a/src/utils/runtime.rs
+++ b/src/utils/runtime.rs
@@ -58,8 +58,11 @@ impl RuntimeWallet {
             Self::Standard(_) => Ok(()),
             #[cfg(any(feature = "sqlite", feature = "redb"))]
             Self::Persisted(wallet, persister) => {
-                wallet.persist(persister)?;
-                Ok(())
+                if wallet.persist(persister)? {
+                    Ok(())
+                } else {
+                    Err(Error::Generic("Wallet changes were not persisted".to_string()))
+                }
             }
         }
     }

--- a/src/utils/runtime.rs
+++ b/src/utils/runtime.rs
@@ -61,9 +61,7 @@ impl RuntimeWallet {
                 if wallet.persist(persister)? {
                     Ok(())
                 } else {
-                    Err(Error::Generic(
-                        "Wallet changes were not persisted".to_string(),
-                    ))
+                    Err(Error::Generic("Wallet changes were not persisted".into()))
                 }
             }
         }

--- a/src/utils/runtime.rs
+++ b/src/utils/runtime.rs
@@ -61,7 +61,9 @@ impl RuntimeWallet {
                 if wallet.persist(persister)? {
                     Ok(())
                 } else {
-                    Err(Error::Generic("Wallet changes were not persisted".to_string()))
+                    Err(Error::Generic(
+                        "Wallet changes were not persisted".to_string(),
+                    ))
                 }
             }
         }


### PR DESCRIPTION
### Description

The `persist()` method of `RuntimeWallet` returns `ok(())` wether or not the wallet was persisted or not. This is bad practice. My changes Return an error when wallet persistence fails instead of silently succeeding when no changes were written.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

Thank you.